### PR TITLE
Add PostgreSQL-backed Streamlit insights dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-DB_HOST=sensoria-2.ics.uci.edu
-DB_PORT=5432
-DB_NAME=datawhisk_capstone
-DB_USER=dcgroup
+DB_HOST=replace_me
+DB_PORT=replace_me
+DB_NAME=replace_me
+DB_USER=replace_me
 DB_PASSWORD=replace_me

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=sensoria-2.ics.uci.edu
+DB_PORT=5432
+DB_NAME=datawhisk_capstone
+DB_USER=dcgroup
+DB_PASSWORD=replace_me

--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ hvac-occupancy-forecasting/
 │   │   └── optimizer.py        # Setpoint optimization, savings estimation
 │   └── viz/                    # Visualization utilities
 │       ├── __init__.py
-│       └── dashboards.py       # Plotting and dashboard functions
+│       ├── dashboards.py            # Plotting helpers
+│       ├── dashboard_data.py        # PostgreSQL query layer for dashboard
+│       ├── dashboard_insights.py    # Insight/narrative derivation
+│       └── streamlit_dashboard.py   # Streamlit dashboard entrypoint
 │
 └── docs/
     ├── system_design.md        # High-level architecture and data flow
@@ -76,19 +79,39 @@ source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
-### 3. Data Access
+### 3. Data Access (PostgreSQL Only)
 
-**Raw data is not stored in Git.** To work with the project:
+The app is configured for **PostgreSQL-only** loading (CSV loaders are disabled).
 
-1. Obtain access to the shared dataset bundle (from Kevin/Nada/Ashwin)
-2. Place files in the corresponding `data/raw/...` subfolders:
-   - `data/raw/occupancy/` - Occupancy CSV files
-   - `data/raw/hvac/` - HVAC data exports
-   - `data/raw/weather/` - Weather data
-   - `data/raw/tou/` - TOU pricing schedules
-   - `data/raw/space_metadata/` - Room/zone metadata
+1. Create `.env` from `.env.example` and fill credentials:
 
-See [`docs/data_dictionary.md`](docs/data_dictionary.md) for filenames, schemas, and time ranges.
+```bash
+cp .env.example .env
+```
+
+2. Install dependencies (includes `psycopg2-binary`):
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Optional connectivity check:
+
+```bash
+PGPASSWORD='...' psql -h <host> -U <user> -d <db_name>
+```
+
+4. Build DB schema dictionary:
+
+```bash
+python3 scripts/build_db_data_dictionary.py
+```
+
+5. Train/evaluate occupancy model from DB:
+
+```bash
+python3 scripts/train_eval_occupancy_model.py --db-table space_occupancy
+```
 
 ### 4. Run Notebooks
 
@@ -96,6 +119,23 @@ Start with the exploration notebook:
 
 ```bash
 jupyter notebook notebooks/01_exploration_opportunity_savings.ipynb
+```
+
+### 5. Run the Streamlit POC Dashboard (Local)
+
+The dashboard reads directly from PostgreSQL and presents separate occupancy and HVAC insights.
+
+Required environment variables (in `.env` or shell):
+- `DB_HOST`
+- `DB_PORT`
+- `DB_NAME`
+- `DB_USER`
+- `DB_PASSWORD`
+
+Run from the repository root:
+
+```bash
+streamlit run src/viz/streamlit_dashboard.py
 ```
 
 ---

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -1,0 +1,192 @@
+create table user_ap_trajectory
+(
+    "user"       varchar(255) not null,
+    access_point varchar(255) not null,
+    beginning    timestamp    not null,
+    "end"        timestamp    not null,
+    primary key ("user", access_point, beginning, "end")
+);
+
+alter table user_ap_trajectory
+    owner to dcgroup;
+
+create index idx_user
+    on user_ap_trajectory ("user");
+
+create index idx_access_point
+    on user_ap_trajectory (access_point);
+
+create index idx_beginning
+    on user_ap_trajectory (beginning);
+
+create index idx_end
+    on user_ap_trajectory ("end");
+
+create table "user_location_trajectory_FINE_V2"
+(
+    "user"    varchar(255) not null,
+    space_id  integer      not null,
+    beginning timestamp    not null,
+    "end"     timestamp    not null,
+    primary key ("user", space_id, beginning, "end")
+);
+
+alter table "user_location_trajectory_FINE_V2"
+    owner to dcgroup;
+
+create index idx_space_id
+    on "user_location_trajectory_FINE_V2" (space_id);
+
+create index idx_ultf_v2_user
+    on "user_location_trajectory_FINE_V2" ("user");
+
+create index idx_ultf_v2_space_id
+    on "user_location_trajectory_FINE_V2" (space_id);
+
+create index idx_ultf_v2_beginning
+    on "user_location_trajectory_FINE_V2" (beginning);
+
+create index idx_ultf_v2_end
+    on "user_location_trajectory_FINE_V2" ("end");
+
+create table observation_merged
+(
+    payload     varchar(255) not null,
+    "timeStamp" timestamp    not null,
+    sensor_id   varchar(255) not null,
+    primary key (payload, "timeStamp", sensor_id)
+);
+
+alter table observation_merged
+    owner to dcgroup;
+
+create index idx_obs_merged_payload
+    on observation_merged (payload);
+
+create index idx_obs_merged_timestamp
+    on observation_merged ("timeStamp");
+
+create index idx_obs_merged_sensor_id
+    on observation_merged (sensor_id);
+
+create table region_to_coverage
+(
+    region_id               integer          not null,
+    space_name              varchar(200)     not null,
+    wapcov_id               integer          not null,
+    sensor                  varchar(200)     not null,
+    intersection_percentage double precision not null,
+    primary key (region_id, space_name, wapcov_id, sensor, intersection_percentage)
+);
+
+alter table region_to_coverage
+    owner to dcgroup;
+
+create index idx_rtc_region_id
+    on region_to_coverage (region_id);
+
+create index idx_rtc_space_name
+    on region_to_coverage (space_name);
+
+create index idx_rtc_wapcov_id
+    on region_to_coverage (wapcov_id);
+
+create index idx_rtc_sensor
+    on region_to_coverage (sensor);
+
+create index idx_rtc_intersection
+    on region_to_coverage (intersection_percentage);
+
+create table space_metadata
+(
+    "roomID"      integer      not null,
+    "typeID"      integer      not null,
+    type          varchar(200) not null,
+    building_room varchar(200) default NULL::character varying,
+    primary key ("roomID", "typeID", type)
+);
+
+alter table space_metadata
+    owner to dcgroup;
+
+create index idx_sm_roomid
+    on space_metadata ("roomID");
+
+create index idx_sm_typeid
+    on space_metadata ("typeID");
+
+create index idx_sm_type
+    on space_metadata (type);
+
+create index idx_sm_building_room
+    on space_metadata (building_room);
+
+create table space
+(
+    space_id        integer not null
+        primary key,
+    space_name      varchar(200) default NULL::character varying,
+    parent_space_id integer,
+    building_room   varchar(200) default NULL::character varying
+);
+
+alter table space
+    owner to dcgroup;
+
+create index idx_spc_space_id
+    on space (space_id);
+
+create index idx_spc_space_name
+    on space (space_name);
+
+create index idx_spc_parent_space_id
+    on space (parent_space_id);
+
+create index idx_spc_building_room
+    on space (building_room);
+
+create table space_occupancy
+(
+    space_id  integer   not null,
+    occupancy integer   not null,
+    beginning timestamp not null,
+    "end"     timestamp not null,
+    primary key (space_id, occupancy, beginning, "end")
+);
+
+alter table space_occupancy
+    owner to dcgroup;
+
+create index idx_occ_occupancy
+    on space_occupancy (occupancy);
+
+create index idx_occ_space_id
+    on space_occupancy (space_id);
+
+create index idx_occ_beginning
+    on space_occupancy (beginning);
+
+create index idx_occ_end
+    on space_occupancy ("end");
+
+create table hvac
+(
+    timestamp timestamp,
+    space_id  text,
+    zone_temp double precision
+);
+
+alter table hvac
+    owner to dcgroup;
+
+create table wifi_data
+(
+    timestamp timestamp,
+    mac       text,
+    wap       text
+);
+
+alter table wifi_data
+    owner to dcgroup;
+
+

--- a/docs/db_data_dictionary.md
+++ b/docs/db_data_dictionary.md
@@ -1,0 +1,102 @@
+# Database Data Dictionary
+
+Generated from PostgreSQL metadata (`information_schema` + `pg_catalog`).
+
+- Tables discovered: **9**
+
+## hvac
+
+- Estimated rows: **2,846,750**
+
+| Column | Type | Nullable | Meaning | Comment |
+|---|---|---|---|---|
+| timestamp | timestamp without time zone | YES | time boundary / observation timestamp |  |
+| space_id | text | YES | entity identifier |  |
+| zone_temp | double precision | YES | temperature measurement |  |
+
+## observation_merged
+
+- Estimated rows: **21,608,349**
+
+| Column | Type | Nullable | Meaning | Comment |
+|---|---|---|---|---|
+| payload | character varying | NO | raw payload or event value |  |
+| timeStamp | timestamp without time zone | NO | time boundary / observation timestamp |  |
+| sensor_id | character varying | NO | network/sensor source identifier |  |
+
+## region_to_coverage
+
+- Estimated rows: **208**
+
+| Column | Type | Nullable | Meaning | Comment |
+|---|---|---|---|---|
+| region_id | integer | NO | entity identifier |  |
+| space_name | character varying | NO | domain-specific field; confirm with data owner |  |
+| wapcov_id | integer | NO | entity identifier |  |
+| sensor | character varying | NO | network/sensor source identifier |  |
+| intersection_percentage | double precision | NO | domain-specific field; confirm with data owner |  |
+
+## space
+
+- Estimated rows: **953**
+
+| Column | Type | Nullable | Meaning | Comment |
+|---|---|---|---|---|
+| space_id | integer | NO | entity identifier |  |
+| space_name | character varying | YES | domain-specific field; confirm with data owner |  |
+| parent_space_id | integer | YES | hierarchical parent reference |  |
+| building_room | character varying | YES | domain-specific field; confirm with data owner |  |
+
+## space_metadata
+
+- Estimated rows: **156**
+
+| Column | Type | Nullable | Meaning | Comment |
+|---|---|---|---|---|
+| roomID | integer | NO | entity identifier |  |
+| typeID | integer | NO | entity identifier |  |
+| type | character varying | NO | domain-specific field; confirm with data owner |  |
+| building_room | character varying | YES | domain-specific field; confirm with data owner |  |
+
+## space_occupancy
+
+- Estimated rows: **4,538,846**
+
+| Column | Type | Nullable | Meaning | Comment |
+|---|---|---|---|---|
+| space_id | integer | NO | entity identifier |  |
+| occupancy | integer | NO | observed occupancy count |  |
+| beginning | timestamp without time zone | NO | time boundary / observation timestamp |  |
+| end | timestamp without time zone | NO | time boundary / observation timestamp |  |
+
+## user_ap_trajectory
+
+- Estimated rows: **8,156,084**
+
+| Column | Type | Nullable | Meaning | Comment |
+|---|---|---|---|---|
+| user | character varying | NO | anonymized user/device identifier |  |
+| access_point | character varying | NO | network/sensor source identifier |  |
+| beginning | timestamp without time zone | NO | time boundary / observation timestamp |  |
+| end | timestamp without time zone | NO | time boundary / observation timestamp |  |
+
+## user_location_trajectory_FINE_V2
+
+- Estimated rows: **5,978,498**
+
+| Column | Type | Nullable | Meaning | Comment |
+|---|---|---|---|---|
+| user | character varying | NO | anonymized user/device identifier |  |
+| space_id | integer | NO | entity identifier |  |
+| beginning | timestamp without time zone | NO | time boundary / observation timestamp |  |
+| end | timestamp without time zone | NO | time boundary / observation timestamp |  |
+
+## wifi_data
+
+- Estimated rows: **873,333**
+
+| Column | Type | Nullable | Meaning | Comment |
+|---|---|---|---|---|
+| timestamp | timestamp without time zone | YES | time boundary / observation timestamp |  |
+| mac | text | YES | anonymized user/device identifier |  |
+| wap | text | YES | network/sensor source identifier |  |

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,10 +24,11 @@ ipykernel>=6.0.0
 python-dateutil>=2.8.0
 pytz>=2023.3
 tqdm>=4.65.0
+psycopg2-binary>=2.9.9
 
 # Data validation (optional)
 # pandera>=0.16.0
 
-# Dashboard (optional, for future use)
-# streamlit>=1.25.0
+# Dashboard
+streamlit>=1.25.0
 # dash>=2.11.0

--- a/scripts/build_db_data_dictionary.py
+++ b/scripts/build_db_data_dictionary.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+Build a DB schema dictionary from PostgreSQL metadata.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.data import load_schema_dictionary  # noqa: E402
+
+
+def infer_meaning(table: str, column: str) -> str:
+    c = column.lower()
+    t = table.lower()
+    if c in {"beginning", "end", "timestamp", "timestamp"}:
+        return "time boundary / observation timestamp"
+    if "occupancy" in c:
+        return "observed occupancy count"
+    if c in {"space_id", "roomid", "typeid", "region_id", "wapcov_id"}:
+        return "entity identifier"
+    if c in {"user", "mac"}:
+        return "anonymized user/device identifier"
+    if "temp" in c:
+        return "temperature measurement"
+    if c in {"access_point", "wap", "sensor", "sensor_id"}:
+        return "network/sensor source identifier"
+    if c == "payload":
+        return "raw payload or event value"
+    if t == "space" and c == "parent_space_id":
+        return "hierarchical parent reference"
+    return "domain-specific field; confirm with data owner"
+
+
+def main():
+    out_csv = PROJECT_ROOT / "data/interim/db_schema_dictionary.csv"
+    out_md = PROJECT_ROOT / "docs/db_data_dictionary.md"
+
+    schema_df = load_schema_dictionary(schema="public", env_path=".env")
+    if schema_df.empty:
+        raise RuntimeError("No schema metadata returned from DB.")
+
+    schema_df = schema_df.copy()
+    schema_df["semantic_meaning"] = schema_df.apply(
+        lambda r: infer_meaning(r["table_name"], r["column_name"]),
+        axis=1,
+    )
+
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    schema_df.to_csv(out_csv, index=False)
+
+    lines = []
+    lines.append("# Database Data Dictionary\n")
+    lines.append("Generated from PostgreSQL metadata (`information_schema` + `pg_catalog`).\n")
+    tables = sorted(schema_df["table_name"].unique().tolist())
+    lines.append(f"- Tables discovered: **{len(tables)}**\n")
+
+    for table in tables:
+        tdf = schema_df[schema_df["table_name"] == table].copy()
+        est_rows = int(tdf["estimated_row_count"].iloc[0]) if len(tdf) else 0
+        lines.append(f"## {table}\n")
+        lines.append(f"- Estimated rows: **{est_rows:,}**\n")
+        lines.append("| Column | Type | Nullable | Meaning | Comment |")
+        lines.append("|---|---|---|---|---|")
+        for _, r in tdf.iterrows():
+            comment = "" if pd.isna(r["column_comment"]) else str(r["column_comment"])
+            lines.append(
+                f"| {r['column_name']} | {r['data_type']} | {r['is_nullable']} | "
+                f"{r['semantic_meaning']} | {comment} |"
+            )
+        lines.append("")
+
+    out_md.write_text("\n".join(lines), encoding="utf-8")
+    print(f"Wrote: {out_csv}")
+    print(f"Wrote: {out_md}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_occupancy_data_dictionary.py
+++ b/scripts/build_occupancy_data_dictionary.py
@@ -1,93 +1,15 @@
 #!/usr/bin/env python3
 """
-Build a data dictionary for occupancy CSV files.
+Deprecated compatibility wrapper.
 
-Usage:
-  python scripts/build_occupancy_data_dictionary.py
+CSV occupancy dictionary generation was removed in DB-only mode.
+This command now delegates to `build_db_data_dictionary.py`.
 """
 
 from pathlib import Path
-import sys
-
-import pandas as pd
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(PROJECT_ROOT))
-
-from src.data.load import load_occupancy  # noqa: E402
-
-
-def infer_semantic(col: str) -> str:
-    c = col.lower()
-    if "access_point" in c:
-        return "access-point identifier"
-    if "interval" in c or "time" in c or "timestamp" in c:
-        return "time bucket start"
-    if c == "count":
-        return "observed occupancy count"
-    if "source" in c:
-        return "source filename"
-    return "unknown"
-
-
-def main():
-    input_dir = PROJECT_ROOT / "data/raw/occupancy/brenhall_ap_15min"
-    output_csv = PROJECT_ROOT / "data/interim/occupancy_data_dictionary.csv"
-    output_md = PROJECT_ROOT / "docs/occupancy_data_dictionary.md"
-
-    df = load_occupancy(str(input_dir), parse_dates=True)
-
-    rows = []
-    for col in df.columns:
-        s = df[col]
-        rows.append(
-            {
-                "column_name": col,
-                "dtype": str(s.dtype),
-                "non_null_count": int(s.notna().sum()),
-                "null_count": int(s.isna().sum()),
-                "null_pct": float((s.isna().mean() * 100).round(4)),
-                "n_unique": int(s.nunique(dropna=True)),
-                "sample_values": " | ".join(map(str, s.dropna().head(3).tolist())),
-                "semantic_meaning": infer_semantic(col),
-            }
-        )
-
-    ddf = pd.DataFrame(rows)
-    output_csv.parent.mkdir(parents=True, exist_ok=True)
-    ddf.to_csv(output_csv, index=False)
-
-    min_ts = df["interval_begin"].min()
-    max_ts = df["interval_begin"].max()
-
-    md = []
-    md.append("# Occupancy Data Dictionary\n")
-    md.append("Generated from `data/raw/occupancy/brenhall_ap_15min/*.csv`.\n")
-    md.append("## Dataset Summary\n")
-    md.append(f"- Rows: **{len(df):,}**")
-    md.append(f"- Columns: **{len(df.columns)}**")
-    md.append(f"- Source files: **{df['source_file'].nunique()}**")
-    md.append(f"- Time range: **{min_ts} -> {max_ts}**\n")
-
-    md.append("## Schema\n")
-    md.append("| Column | Dtype | Null % | Unique | Meaning | Example |")
-    md.append("|---|---:|---:|---:|---|---|")
-
-    for _, r in ddf.iterrows():
-        md.append(
-            f"| {r['column_name']} | {r['dtype']} | {r['null_pct']:.4f}% | {r['n_unique']} | {r['semantic_meaning']} | {str(r['sample_values']).replace('|', ', ')} |"
-        )
-
-    md.append("\n## Notes\n")
-    md.append("- Raw source schemas were normalized to: `access_point`, `interval_begin`, `count`.\n")
-    md.append("- `interval_begin_time` and `ap` are mapped to canonical names when present.\n")
-    md.append("- `count` is coerced to numeric for analysis readiness.\n")
-
-    output_md.write_text("\n".join(md), encoding="utf-8")
-
-    print(f"Wrote: {output_csv}")
-    print(f"Wrote: {output_md}")
+import runpy
 
 
 if __name__ == "__main__":
-    main()
+    target = Path(__file__).resolve().parent / "build_db_data_dictionary.py"
+    runpy.run_path(str(target), run_name="__main__")

--- a/scripts/load_brenhall_hvac.py
+++ b/scripts/load_brenhall_hvac.py
@@ -1,56 +1,9 @@
 #!/usr/bin/env python3
 """
-Load Bren Hall weekly HVAC raw CSV exports into one combined dataframe.
-
-Usage:
-  python scripts/load_brenhall_hvac.py
-  python scripts/load_brenhall_hvac.py --input data/raw/hvac/brenhall_2024_weekly --output data/interim/brenhall_2024_hvac_combined.csv
+Deprecated: CSV loading was removed in DB-only mode.
 """
 
-import argparse
-from pathlib import Path
-import sys
-
-# Ensure local src/ is importable when running as a script
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(PROJECT_ROOT))
-
-from src.data.load import load_hvac  # noqa: E402
-
-
-def main():
-    parser = argparse.ArgumentParser(description="Combine Bren Hall HVAC weekly CSV files")
-    parser.add_argument(
-        "--input",
-        default="data/raw/hvac/brenhall_2024_weekly",
-        help="Input directory containing weekly Bren Hall HVAC CSV files",
-    )
-    parser.add_argument(
-        "--output",
-        default="data/interim/brenhall_2024_hvac_combined.csv",
-        help="Output combined CSV path",
-    )
-    parser.add_argument(
-        "--no-parse-dates",
-        action="store_true",
-        help="Do not parse Timestamp as datetime",
-    )
-
-    args = parser.parse_args()
-
-    input_path = PROJECT_ROOT / args.input
-    output_path = PROJECT_ROOT / args.output
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-
-    df = load_hvac(str(input_path), parse_dates=not args.no_parse_dates)
-    df.to_csv(output_path, index=False)
-
-    print(f"Saved combined file: {output_path}")
-    print(f"Rows: {len(df):,}")
-    print(f"Columns: {len(df.columns):,}")
-    if "Timestamp" in df.columns:
-        print(f"Timestamp range: {df['Timestamp'].min()} -> {df['Timestamp'].max()}")
-
-
 if __name__ == "__main__":
-    main()
+    raise SystemExit(
+        "CSV HVAC loading is disabled. Use PostgreSQL loaders via src.data.load_hvac_from_db."
+    )

--- a/scripts/load_occupancy.py
+++ b/scripts/load_occupancy.py
@@ -1,42 +1,7 @@
 #!/usr/bin/env python3
-"""Combine occupancy CSV files into one normalized dataset."""
-
-import argparse
-from pathlib import Path
-import sys
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(PROJECT_ROOT))
-
-from src.data.load import load_occupancy  # noqa: E402
-
-
-def main():
-    parser = argparse.ArgumentParser(description="Combine occupancy CSVs")
-    parser.add_argument(
-        "--input",
-        default="data/raw/occupancy/brenhall_ap_15min",
-        help="Input directory containing occupancy CSV files",
-    )
-    parser.add_argument(
-        "--output",
-        default="data/interim/occupancy_15min_combined.csv",
-        help="Output combined CSV path",
-    )
-    args = parser.parse_args()
-
-    in_path = PROJECT_ROOT / args.input
-    out_path = PROJECT_ROOT / args.output
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-
-    df = load_occupancy(str(in_path), parse_dates=True)
-    df.to_csv(out_path, index=False)
-
-    print(f"Saved combined file: {out_path}")
-    print(f"Rows: {len(df):,}")
-    print(f"Columns: {len(df.columns):,}")
-    print(f"Time range: {df['interval_begin'].min()} -> {df['interval_begin'].max()}")
-
+"""Deprecated: CSV loading was removed in DB-only mode."""
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(
+        "CSV occupancy loading is disabled. Use PostgreSQL loaders via src.data.load_occupancy_from_db."
+    )

--- a/scripts/train_eval_occupancy_model.py
+++ b/scripts/train_eval_occupancy_model.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Train and evaluate the occupancy prediction model.
+
+Source of truth:
+- PostgreSQL only
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+import sys
+from typing import Optional
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.data import (  # noqa: E402
+    load_occupancy_from_db,
+    load_weather_from_db,
+    prepare_occupancy_forecast_dataset,
+)
+from src.models import ProphetOccupancyModel  # noqa: E402
+
+
+def _weather_for_range(weather_df: Optional[pd.DataFrame], start: pd.Timestamp, end: pd.Timestamp):
+    if weather_df is None or weather_df.empty:
+        return None
+    weather = weather_df.copy()
+    if "timestamp" not in weather.columns:
+        return weather
+    weather["timestamp"] = pd.to_datetime(weather["timestamp"], errors="coerce")
+    return weather[(weather["timestamp"] >= start) & (weather["timestamp"] <= end)].copy()
+
+
+def run(args: argparse.Namespace) -> int:
+    occ_source = load_occupancy_from_db(
+        table_name=args.db_table,
+        schema=args.db_schema,
+        env_path=args.env_path,
+    )
+
+    weather_df = None
+    if args.weather_table:
+        weather_df = load_weather_from_db(
+            table_name=args.weather_table,
+            schema=args.weather_schema,
+            timestamp_col=args.weather_timestamp_col,
+            temp_col=args.weather_temp_col,
+            env_path=args.env_path,
+        )
+
+    # Normalize db shape to preprocessing expectations.
+    if "interval_begin" in occ_source.columns and "count" in occ_source.columns:
+        occ_source = occ_source.rename(
+            columns={"interval_begin": "timestamp", "count": "occupancy_count"}
+        )
+
+    if args.zone_id:
+        zones = [str(args.zone_id)]
+    else:
+        zone_col = "zone_id" if "zone_id" in occ_source.columns else "access_point"
+        zones = sorted(occ_source[zone_col].astype(str).dropna().unique().tolist())
+        if args.max_zones is not None:
+            zones = zones[: args.max_zones]
+
+    if not zones:
+        raise ValueError("No zones found in occupancy source.")
+
+    metrics_rows = []
+    forecast_frames = []
+    pass_count = 0
+
+    for zone in zones:
+        zone_features = prepare_occupancy_forecast_dataset(
+            occ_df=occ_source,
+            weather_df=weather_df,
+            zone_id=zone,
+            freq=args.freq,
+            dropna_for_training=True,
+        )
+        model_df = zone_features.rename(
+            columns={"timestamp": "ds", "occupancy_count": "y"}
+        )[["ds", "y", "outside_temp"]]
+
+        split_idx = int(len(model_df) * (1.0 - args.test_ratio))
+        if split_idx < 1 or split_idx >= len(model_df):
+            metrics_rows.append(
+                {
+                    "zone_id": zone,
+                    "status": "insufficient_data",
+                    "binary_accuracy": 0.0,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "f1": 0.0,
+                    "mae": float("nan"),
+                    "pass": False,
+                }
+            )
+            continue
+
+        train_df = model_df.iloc[:split_idx].reset_index(drop=True)
+        test_df = model_df.iloc[split_idx:].reset_index(drop=True)
+
+        model = ProphetOccupancyModel(zone_id=zone, freq=args.freq)
+        model.fit(train_df)
+        eval_metrics = model.evaluate(test_df)
+
+        passed = eval_metrics.get("binary_accuracy", 0.0) >= args.accuracy_threshold
+        if passed:
+            pass_count += 1
+
+        metrics_rows.append(
+            {
+                "zone_id": zone,
+                **eval_metrics,
+                "status": "ok",
+                "pass": passed,
+            }
+        )
+
+        test_start = pd.Timestamp(test_df["ds"].min())
+        test_end = pd.Timestamp(test_df["ds"].max())
+        test_weather = _weather_for_range(weather_df, test_start, test_end)
+
+        forecast = model.predict_date_range(
+            start_ts=test_start,
+            end_ts=test_end,
+            weather_future_df=test_weather,
+        )
+        forecast = forecast.rename(columns={"ds": "timestamp"})
+        forecast["zone_id"] = zone
+        forecast_frames.append(forecast)
+
+    metrics_df = pd.DataFrame(metrics_rows)
+    forecasts_df = (
+        pd.concat(forecast_frames, ignore_index=True)
+        if forecast_frames
+        else pd.DataFrame(
+            columns=[
+                "timestamp",
+                "zone_id",
+                "pred_occupancy_count",
+                "pred_is_occupied",
+            ]
+        )
+    )
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    metrics_path = output_dir / f"occupancy_model_metrics_{stamp}.csv"
+    forecast_path = output_dir / f"occupancy_model_forecasts_{stamp}.csv"
+
+    metrics_df.to_csv(metrics_path, index=False)
+    forecasts_df.to_csv(forecast_path, index=False)
+
+    print(f"Wrote metrics: {metrics_path}")
+    print(f"Wrote forecasts: {forecast_path}")
+    print("")
+    print(metrics_df.to_string(index=False))
+
+    global_pass = pass_count >= args.min_passing_zones
+    if global_pass:
+        print("")
+        print(
+            f"PASS: {pass_count} zone(s) met binary_accuracy >= {args.accuracy_threshold:.2f} "
+            f"(required: {args.min_passing_zones})."
+        )
+        return 0
+
+    print("")
+    print(
+        f"FAIL: only {pass_count} zone(s) met binary_accuracy >= {args.accuracy_threshold:.2f} "
+        f"(required: {args.min_passing_zones})."
+    )
+    return 1
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train/eval occupancy prediction model.")
+    parser.add_argument("--env-path", default=".env")
+    parser.add_argument("--db-schema", default="public")
+    parser.add_argument("--db-table", default="space_occupancy")
+    parser.add_argument("--weather-schema", default="public")
+    parser.add_argument("--weather-table", default=None)
+    parser.add_argument("--weather-timestamp-col", default="timestamp")
+    parser.add_argument("--weather-temp-col", default="outside_temp")
+    parser.add_argument("--zone-id", default=None)
+    parser.add_argument("--max-zones", type=int, default=None)
+    parser.add_argument("--freq", default="15min")
+    parser.add_argument("--test-ratio", type=float, default=0.2)
+    parser.add_argument("--accuracy-threshold", type=float, default=0.8)
+    parser.add_argument("--min-passing-zones", type=int, default=1)
+    parser.add_argument("--output-dir", default="data/processed")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(parse_args()))

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,15 +1,47 @@
 """Data loading and preprocessing utilities for HVAC occupancy forecasting."""
 
-from .load import load_occupancy, load_hvac, load_weather, load_tou, load_space_metadata, fetch_historical_weather
-from .preprocess import merge_occupancy_hvac, engineer_features
+from .load import (
+    get_db_config,
+    get_postgres_connection,
+    load_hvac_from_db,
+    load_hvac,
+    load_occupancy,
+    load_occupancy_from_db,
+    load_schema_dictionary,
+    load_space_metadata,
+    load_space_metadata_from_db,
+    load_table_from_db,
+    load_tou,
+    load_tou_from_db,
+    load_weather,
+    load_weather_from_db,
+)
+from .preprocess import (
+    engineer_features,
+    merge_occupancy_hvac,
+    normalize_occupancy,
+    normalize_weather,
+    prepare_occupancy_forecast_dataset,
+)
 
 __all__ = [
     "load_occupancy",
     "load_hvac",
     "load_weather",
-    "fetch_historical_weather",
     "load_tou",
     "load_space_metadata",
+    "get_db_config",
+    "get_postgres_connection",
+    "load_table_from_db",
+    "load_schema_dictionary",
+    "load_occupancy_from_db",
+    "load_weather_from_db",
+    "load_hvac_from_db",
+    "load_tou_from_db",
+    "load_space_metadata_from_db",
     "merge_occupancy_hvac",
     "engineer_features",
+    "normalize_occupancy",
+    "normalize_weather",
+    "prepare_occupancy_forecast_dataset",
 ]

--- a/src/data/load.py
+++ b/src/data/load.py
@@ -1,19 +1,23 @@
 """
 Data loading utilities for HVAC occupancy forecasting.
 
-Functions to load raw data from various sources:
-- Occupancy data (Wi-Fi/locator-derived)
-- HVAC data (setpoints, states, energy use)
-- Weather data (historical)
-- Time-of-use (TOU) pricing data
-- Space metadata (room IDs, internal/external, floor, area)
+DB-only source of truth:
+- PostgreSQL loading via .env credentials
 """
 
+from __future__ import annotations
+
+import os
 import re
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional, Sequence
 
 import pandas as pd
+
+try:
+    import psycopg2
+except ImportError:  # pragma: no cover - handled at runtime
+    psycopg2 = None
 
 
 def _dedupe_columns(columns: List[str]) -> List[str]:
@@ -34,7 +38,6 @@ def _dedupe_columns(columns: List[str]) -> List[str]:
 
 def _natural_week_sort_key(path: Path):
     """Sort weekly files by month/day encoded in filename when possible."""
-    # Matches names like BrenHall2024Week_May12.csv
     m = re.search(r"Week_([A-Za-z]+)(\d+)", path.stem)
     if not m:
         return (path.stem,)
@@ -61,236 +64,307 @@ def _natural_week_sort_key(path: Path):
 
 def load_occupancy(path: str, parse_dates: bool = True) -> pd.DataFrame:
     """
-    Load occupancy data from a CSV file OR a directory of CSV files.
-
-    Supported input schemas are normalized to common columns:
-      - access_point
-      - interval_begin
-      - count
-      - source_file
-
-    Known source variants:
-      1) ap, interval_begin_time, count
-      2) access_point, interval_begin, count
-
-    Args:
-        path: Path to one CSV file or a folder of CSV files.
-        parse_dates: Whether to parse interval_begin as datetime.
-
-    Returns:
-        Normalized occupancy dataframe.
+    CSV loading is disabled. Use `load_occupancy_from_db`.
     """
-    input_path = Path(path)
-
-    if input_path.is_file():
-        files = [input_path]
-    elif input_path.is_dir():
-        files = sorted(input_path.glob("*.csv"))
-    else:
-        raise FileNotFoundError(f"Occupancy path does not exist: {path}")
-
-    if not files:
-        raise FileNotFoundError(f"No CSV files found at: {path}")
-
-    frames = []
-    for f in files:
-        df = pd.read_csv(f, low_memory=False)
-        df.columns = _dedupe_columns(df.columns.tolist())
-
-        rename_map = {}
-        if "ap" in df.columns:
-            rename_map["ap"] = "access_point"
-        if "interval_begin_time" in df.columns:
-            rename_map["interval_begin_time"] = "interval_begin"
-
-        if rename_map:
-            df = df.rename(columns=rename_map)
-
-        for required_col in ["access_point", "interval_begin", "count"]:
-            if required_col not in df.columns:
-                raise ValueError(
-                    f"Missing required column '{required_col}' in {f.name}. "
-                    f"Columns found: {list(df.columns)[:10]}..."
-                )
-
-        keep_cols = ["access_point", "interval_begin", "count"]
-        out = df[keep_cols].copy()
-        out["source_file"] = f.name
-
-        if parse_dates:
-            out["interval_begin"] = pd.to_datetime(out["interval_begin"], errors="coerce")
-
-        # Normalize type
-        out["count"] = pd.to_numeric(out["count"], errors="coerce")
-
-        frames.append(out)
-
-    occ = pd.concat(frames, ignore_index=True)
-
-    if parse_dates and "interval_begin" in occ.columns:
-        occ = occ.sort_values("interval_begin", kind="stable").reset_index(drop=True)
-
-    return occ
+    raise NotImplementedError(
+        "CSV loading is disabled. Use PostgreSQL loaders (load_occupancy_from_db)."
+    )
 
 
 def load_hvac(path: str, parse_dates: bool = True) -> pd.DataFrame:
     """
-    Load raw HVAC data from a CSV file OR a directory of weekly CSV files.
-
-    Supported patterns:
-    - Single file: data/raw/hvac/some_export.csv
-    - Directory:   data/raw/hvac/brenhall_2024_weekly/
-
-    Notes for Bren Hall weekly exports:
-    - Very wide schema (thousands of columns)
-    - Some duplicate header names are expected
-    - Timestamp column is expected to be "Timestamp"
-
-    Args:
-        path: Path to one CSV file or a folder of CSV files.
-        parse_dates: Whether to parse timestamp columns as datetime.
-
-    Returns:
-        Combined DataFrame sorted by Timestamp when available.
+    CSV loading is disabled. Use `load_hvac_from_db`.
     """
-    input_path = Path(path)
-
-    if input_path.is_file():
-        files = [input_path]
-    elif input_path.is_dir():
-        files = sorted(input_path.glob("*.csv"), key=_natural_week_sort_key)
-    else:
-        raise FileNotFoundError(f"HVAC path does not exist: {path}")
-
-    if not files:
-        raise FileNotFoundError(f"No CSV files found at: {path}")
-
-    frames = []
-    for f in files:
-        df = pd.read_csv(f, low_memory=False)
-        df.columns = _dedupe_columns(df.columns.tolist())
-        df["source_file"] = f.name
-        frames.append(df)
-
-    hvac = pd.concat(frames, ignore_index=True)
-
-    if parse_dates and "Timestamp" in hvac.columns:
-        # Example source format:
-        # 2024-04-28T00:00:00-07:00 Los_Angeles
-        # Keep only the ISO8601 portion before the first space.
-        ts = hvac["Timestamp"].astype(str).str.split(" ").str[0]
-        hvac["Timestamp"] = pd.to_datetime(ts, errors="coerce")
-        hvac = hvac.sort_values("Timestamp", kind="stable").reset_index(drop=True)
-
-    return hvac
+    raise NotImplementedError(
+        "CSV loading is disabled. Use PostgreSQL loaders (load_hvac_from_db)."
+    )
 
 
 def load_weather(path: str, parse_dates: bool = True) -> pd.DataFrame:
     """
-    Load historical weather data.
-
-    Weather data should be aligned by timestamp with occupancy/HVAC data
-    and includes temperature, humidity, etc.
-
-    Args:
-        path: Path to the weather data CSV file.
-        parse_dates: Whether to parse timestamp columns as datetime.
-
-    Returns:
-        DataFrame with columns like: timestamp, temperature, humidity, etc.
-
-    TODO:
-        - Determine weather data source (NOAA, local station, etc.)
-        - Handle timezone alignment with building data
-        - Add interpolation for missing timestamps
+    CSV loading is disabled. Use `load_weather_from_db`.
     """
-    # TODO: Implement actual loading logic once data format is known
-    raise NotImplementedError("Implement once raw data format is confirmed")
+    raise NotImplementedError(
+        "CSV loading is disabled. Use PostgreSQL loaders (load_weather_from_db)."
+    )
 
-import pandas as pd
-import requests
 
-def fetch_historical_weather(lat=33.6695, lon=-117.8231, start_date='2017-08-28', end_date='2018-01-05'):
+def fetch_historical_weather(
+    lat: float = 33.6695,
+    lon: float = -117.8231,
+    start_date: str = "2017-08-28",
+    end_date: str = "2018-01-05",
+) -> pd.DataFrame:
     """
-    Fetches historical hourly temperature data from Open-Meteo.
-    Defaults are set to Irvine, CA for the dates in the occupancy dataset.
+    Disabled in DB-only mode.
     """
-    url = "https://archive-api.open-meteo.com/v1/archive"
-    
-    params = {
-        "latitude": lat,
-        "longitude": lon,
-        "start_date": start_date,
-        "end_date": end_date,
-        "hourly": "temperature_2m",
-        "temperature_unit": "fahrenheit",
-        "timezone": "America/Los_Angeles"
-    }
-    
-    print("Fetching weather data...")
-    response = requests.get(url, params=params)
-    response.raise_for_status() # Check for any errors
-    
-    data = response.json()
-    
-    # Extract the time and temperature arrays
-    times = data['hourly']['time']
-    temps = data['hourly']['temperature_2m']
-    
-    # Create a DataFrame
-    weather_df = pd.DataFrame({
-        'timestamp': pd.to_datetime(times),
-        'outside_temp': temps
-    })
-    
-    # Set the index to match our pipeline structure
-    weather_df = weather_df.set_index('timestamp')
-    
-    return weather_df
+    raise NotImplementedError(
+        "Weather API loading is disabled in DB-only mode. Use load_weather_from_db."
+    )
 
 
 def load_tou(path: str, parse_dates: bool = True) -> pd.DataFrame:
     """
-    Load time-of-use (TOU) electricity pricing data.
-
-    TOU data contains electricity prices by time period (peak, off-peak, etc.)
-    used for estimating cost savings from HVAC optimization.
-
-    Args:
-        path: Path to the TOU pricing data CSV file.
-        parse_dates: Whether to parse timestamp/time columns as datetime.
-
-    Returns:
-        DataFrame with columns like: time_period, rate_kwh, period_type.
-
-    TODO:
-        - Determine TOU schedule format (hourly, period-based, etc.)
-        - Handle seasonal rate variations
-        - Support multiple utility rate structures
+    CSV loading is disabled. Use `load_tou_from_db`.
     """
-    # TODO: Implement actual loading logic once data format is known
-    raise NotImplementedError("Implement once raw data format is confirmed")
+    raise NotImplementedError(
+        "CSV loading is disabled. Use PostgreSQL loaders (load_tou_from_db)."
+    )
 
 
 def load_space_metadata(path: str) -> pd.DataFrame:
     """
-    Load space/room metadata.
-
-    Metadata includes room IDs, whether rooms are internal or external,
-    floor numbers, areas, and other static attributes.
-
-    Args:
-        path: Path to the space metadata CSV file.
-
-    Returns:
-        DataFrame with columns like: zone_id, room_name, is_external, floor, area_sqft.
-
-    TODO:
-        - Determine metadata schema from facilities data
-        - Add validation for zone_id consistency with other data
-        - Include HVAC zone to room mapping if needed
+    CSV loading is disabled. Use `load_space_metadata_from_db`.
     """
-    # TODO: Implement actual loading logic once data format is known
-    raise NotImplementedError("Implement once raw data format is confirmed")
+    raise NotImplementedError(
+        "CSV loading is disabled. Use PostgreSQL loaders (load_space_metadata_from_db)."
+    )
 
 
+def _read_env_file(path: str = ".env") -> Dict[str, str]:
+    env_path = Path(path)
+    if not env_path.exists():
+        return {}
+
+    parsed: Dict[str, str] = {}
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip("'").strip('"')
+        parsed[key] = value
+    return parsed
+
+
+def get_db_config(env_path: str = ".env", **overrides) -> Dict[str, str]:
+    """
+    Build DB config from environment variables + .env + explicit overrides.
+    """
+    file_values = _read_env_file(env_path)
+    merged = {**file_values, **os.environ, **overrides}
+
+    config = {
+        "host": merged.get("DB_HOST", merged.get("PGHOST", "")),
+        "port": str(merged.get("DB_PORT", merged.get("PGPORT", "5432"))),
+        "dbname": merged.get("DB_NAME", merged.get("PGDATABASE", "")),
+        "user": merged.get("DB_USER", merged.get("PGUSER", "")),
+        "password": merged.get("DB_PASSWORD", merged.get("PGPASSWORD", "")),
+    }
+
+    missing = [k for k, v in config.items() if not v]
+    if missing:
+        raise ValueError(
+            "Missing DB config values: "
+            f"{missing}. Set DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD."
+        )
+    return config
+
+
+def get_postgres_connection(env_path: str = ".env", **overrides):
+    """
+    Create a psycopg2 connection from .env/environment config.
+    """
+    if psycopg2 is None:
+        raise ImportError(
+            "psycopg2 is not installed. Install 'psycopg2-binary' to enable DB loading."
+        )
+    config = get_db_config(env_path=env_path, **overrides)
+    return psycopg2.connect(**config)
+
+
+def _query_dataframe(conn, query: str, params: Optional[Sequence] = None) -> pd.DataFrame:
+    with conn.cursor() as cur:
+        cur.execute(query, params if params is not None else [])
+        columns = [desc[0] for desc in cur.description]
+        rows = cur.fetchall()
+    return pd.DataFrame(rows, columns=columns)
+
+
+def _validate_identifier(identifier: str, label: str) -> None:
+    if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", identifier):
+        raise ValueError(f"Invalid {label}: {identifier!r}")
+
+
+def load_table_from_db(
+    table_name: str,
+    schema: str = "public",
+    columns: Optional[Sequence[str]] = None,
+    where_clause: Optional[str] = None,
+    limit: Optional[int] = None,
+    parse_dates: Optional[Sequence[str]] = None,
+    env_path: str = ".env",
+) -> pd.DataFrame:
+    """
+    Load a database table into a DataFrame.
+
+    Note:
+      where_clause is inserted as-is. Prefer trusted static SQL only.
+    """
+    _validate_identifier(schema, "schema")
+    _validate_identifier(table_name, "table_name")
+    if columns:
+        for col in columns:
+            _validate_identifier(col, "column")
+
+    cols_sql = ", ".join(columns) if columns else "*"
+    query = f'SELECT {cols_sql} FROM "{schema}"."{table_name}"'
+    if where_clause:
+        query += f" WHERE {where_clause}"
+    if limit is not None:
+        query += f" LIMIT {int(limit)}"
+
+    with get_postgres_connection(env_path=env_path) as conn:
+        df = _query_dataframe(conn, query=query)
+
+    if parse_dates:
+        for col in parse_dates:
+            if col in df.columns:
+                df[col] = pd.to_datetime(df[col], errors="coerce")
+    return df
+
+
+def load_schema_dictionary(schema: str = "public", env_path: str = ".env") -> pd.DataFrame:
+    """
+    Load schema metadata with column comments and estimated row counts.
+    """
+    query = """
+    SELECT
+      c.table_schema,
+      c.table_name,
+      c.column_name,
+      c.ordinal_position,
+      c.data_type,
+      c.is_nullable,
+      c.column_default,
+      pgd.description AS column_comment,
+      COALESCE(st.n_live_tup, 0)::bigint AS estimated_row_count
+    FROM information_schema.columns c
+    LEFT JOIN pg_catalog.pg_namespace ns
+      ON ns.nspname = c.table_schema
+    LEFT JOIN pg_catalog.pg_class cls
+      ON cls.relnamespace = ns.oid
+     AND cls.relname = c.table_name
+    LEFT JOIN pg_catalog.pg_description pgd
+      ON pgd.objoid = cls.oid
+     AND pgd.objsubid = c.ordinal_position
+    LEFT JOIN pg_catalog.pg_stat_user_tables st
+      ON st.schemaname = c.table_schema
+     AND st.relname = c.table_name
+    WHERE c.table_schema = %s
+    ORDER BY c.table_name, c.ordinal_position;
+    """
+    with get_postgres_connection(env_path=env_path) as conn:
+        return _query_dataframe(conn, query=query, params=[schema])
+
+
+def load_occupancy_from_db(
+    table_name: str = "space_occupancy",
+    schema: str = "public",
+    env_path: str = ".env",
+    zone_id: Optional[str] = None,
+) -> pd.DataFrame:
+    """
+    Load occupancy series from a PostgreSQL table and normalize to:
+    [zone_id, interval_begin, count].
+    """
+    _validate_identifier(schema, "schema")
+    _validate_identifier(table_name, "table_name")
+
+    params = None
+    if table_name == "space_occupancy":
+        query = (
+            f'SELECT space_id::text AS zone_id, beginning AS interval_begin, '
+            f"occupancy::double precision AS count "
+            f'FROM "{schema}"."space_occupancy"'
+        )
+        if zone_id is not None:
+            query += " WHERE space_id::text = %s"
+            params = [str(zone_id)]
+    else:
+        query = f'SELECT * FROM "{schema}"."{table_name}"'
+
+    with get_postgres_connection(env_path=env_path) as conn:
+        df = _query_dataframe(conn, query=query, params=params)
+
+    if "interval_begin" in df.columns:
+        df["interval_begin"] = pd.to_datetime(df["interval_begin"], errors="coerce")
+    if "count" in df.columns:
+        df["count"] = pd.to_numeric(df["count"], errors="coerce")
+    return df
+
+
+def load_weather_from_db(
+    table_name: str,
+    schema: str = "public",
+    timestamp_col: str = "timestamp",
+    temp_col: str = "outside_temp",
+    env_path: str = ".env",
+) -> pd.DataFrame:
+    """
+    Load weather series from PostgreSQL and normalize to:
+    [timestamp, outside_temp].
+    """
+    _validate_identifier(schema, "schema")
+    _validate_identifier(table_name, "table_name")
+    _validate_identifier(timestamp_col, "timestamp_col")
+    _validate_identifier(temp_col, "temp_col")
+
+    query = (
+        f'SELECT {timestamp_col} AS timestamp, '
+        f"{temp_col}::double precision AS outside_temp "
+        f'FROM "{schema}"."{table_name}"'
+    )
+    with get_postgres_connection(env_path=env_path) as conn:
+        df = _query_dataframe(conn, query=query)
+
+    df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
+    df["outside_temp"] = pd.to_numeric(df["outside_temp"], errors="coerce")
+    return df.dropna(subset=["timestamp"]).sort_values("timestamp").reset_index(drop=True)
+
+
+def load_hvac_from_db(
+    table_name: str = "hvac",
+    schema: str = "public",
+    env_path: str = ".env",
+) -> pd.DataFrame:
+    """
+    Load HVAC table from PostgreSQL.
+    """
+    return load_table_from_db(
+        table_name=table_name,
+        schema=schema,
+        env_path=env_path,
+        parse_dates=["timestamp"],
+    )
+
+
+def load_tou_from_db(
+    table_name: str,
+    schema: str = "public",
+    env_path: str = ".env",
+) -> pd.DataFrame:
+    """
+    Load TOU table from PostgreSQL.
+    """
+    return load_table_from_db(
+        table_name=table_name,
+        schema=schema,
+        env_path=env_path,
+    )
+
+
+def load_space_metadata_from_db(
+    table_name: str = "space_metadata",
+    schema: str = "public",
+    env_path: str = ".env",
+) -> pd.DataFrame:
+    """
+    Load space metadata table from PostgreSQL.
+    """
+    return load_table_from_db(
+        table_name=table_name,
+        schema=schema,
+        env_path=env_path,
+    )

--- a/src/data/preprocess.py
+++ b/src/data/preprocess.py
@@ -1,13 +1,181 @@
 """
 Data preprocessing and feature engineering for HVAC occupancy forecasting.
-
-Functions for cleaning, merging, and transforming raw data into
-feature-ready datasets for modeling and control optimization.
 """
 
-import pandas as pd
+from __future__ import annotations
+
+import logging
+from typing import List, Optional, Sequence
+
 import numpy as np
-from typing import Optional, List
+import pandas as pd
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_LAG_PERIODS = [1, 4, 96]
+
+
+def _pick_column(columns: Sequence[str], candidates: Sequence[str], label: str) -> str:
+    for candidate in candidates:
+        if candidate in columns:
+            return candidate
+    raise ValueError(f"Could not find {label} column. Tried: {list(candidates)}")
+
+
+def normalize_occupancy(
+    occ_df: pd.DataFrame,
+    zone_id: Optional[str] = None,
+) -> pd.DataFrame:
+    """
+    Normalize occupancy input to canonical columns:
+    [timestamp, zone_id, occupancy_count].
+    """
+    columns = list(occ_df.columns)
+    timestamp_col = _pick_column(
+        columns, ["timestamp", "interval_begin", "beginning", "ds"], "timestamp"
+    )
+    zone_col = _pick_column(
+        columns,
+        ["zone_id", "access_point", "space_id", "ap", "user"],
+        "zone identifier",
+    )
+    occupancy_col = _pick_column(
+        columns,
+        ["occupancy_count", "count", "occupancy", "y"],
+        "occupancy",
+    )
+
+    out = occ_df[[timestamp_col, zone_col, occupancy_col]].copy()
+    out.columns = ["timestamp", "zone_id", "occupancy_count"]
+    out["timestamp"] = pd.to_datetime(out["timestamp"], errors="coerce")
+    out["zone_id"] = out["zone_id"].astype(str)
+    out["occupancy_count"] = pd.to_numeric(out["occupancy_count"], errors="coerce")
+    out = out.dropna(subset=["timestamp", "zone_id", "occupancy_count"])
+
+    if zone_id is not None:
+        out = out[out["zone_id"] == str(zone_id)]
+
+    if out.empty:
+        raise ValueError("No occupancy rows available after normalization/filtering")
+
+    duplicate_rows = int(out.duplicated(subset=["timestamp", "zone_id"]).sum())
+    if duplicate_rows:
+        LOGGER.info(
+            "Found %s duplicate occupancy rows per [timestamp, zone_id]; aggregating by mean.",
+            duplicate_rows,
+        )
+
+    out = (
+        out.groupby(["timestamp", "zone_id"], as_index=False)["occupancy_count"]
+        .mean()
+        .sort_values(["zone_id", "timestamp"])
+        .reset_index(drop=True)
+    )
+    return out
+
+
+def normalize_weather(weather_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Normalize weather input to canonical columns:
+    [timestamp, outside_temp].
+    """
+    columns = list(weather_df.columns)
+    timestamp_col = _pick_column(columns, ["timestamp", "time", "ds"], "weather timestamp")
+    temp_col = _pick_column(
+        columns,
+        ["outside_temp", "temperature", "temp", "temperature_2m", "y"],
+        "weather temperature",
+    )
+
+    out = weather_df[[timestamp_col, temp_col]].copy()
+    out.columns = ["timestamp", "outside_temp"]
+    out["timestamp"] = pd.to_datetime(out["timestamp"], errors="coerce")
+    out["outside_temp"] = pd.to_numeric(out["outside_temp"], errors="coerce")
+    out = out.dropna(subset=["timestamp"]).sort_values("timestamp")
+    out = out.groupby("timestamp", as_index=False)["outside_temp"].mean()
+    return out
+
+
+def prepare_occupancy_forecast_dataset(
+    occ_df: pd.DataFrame,
+    weather_df: Optional[pd.DataFrame] = None,
+    zone_id: Optional[str] = None,
+    freq: str = "15min",
+    lag_periods: Optional[List[int]] = None,
+    dropna_for_training: bool = True,
+) -> pd.DataFrame:
+    """
+    Build deterministic features for occupancy forecasting.
+
+    Output columns include:
+    - timestamp, zone_id, occupancy_count, is_occupied
+    - hour, day_of_week, is_weekend
+    - occupancy_lag_{k}
+    - outside_temp
+    """
+    if lag_periods is None:
+        lag_periods = DEFAULT_LAG_PERIODS
+
+    occ = normalize_occupancy(occ_df, zone_id=zone_id)
+    if zone_id is None:
+        unique_zones = occ["zone_id"].unique()
+        if len(unique_zones) != 1:
+            raise ValueError(
+                "prepare_occupancy_forecast_dataset requires a single zone. "
+                "Pass zone_id explicitly."
+            )
+        zone_id = str(unique_zones[0])
+    else:
+        zone_id = str(zone_id)
+
+    occ = occ[occ["zone_id"] == zone_id].copy()
+    occ = occ.set_index("timestamp").sort_index()
+    full_index = pd.date_range(occ.index.min(), occ.index.max(), freq=freq)
+    occ = occ.reindex(full_index)
+    occ.index.name = "timestamp"
+    occ["zone_id"] = zone_id
+
+    missing_occ = int(occ["occupancy_count"].isna().sum())
+    if missing_occ:
+        LOGGER.info("Imputing %s missing occupancy points with 0.", missing_occ)
+    occ["occupancy_count"] = occ["occupancy_count"].fillna(0.0).clip(lower=0.0)
+
+    if weather_df is not None:
+        weather = normalize_weather(weather_df)
+        weather = weather.set_index("timestamp").sort_index()
+        weather = weather.resample(freq).interpolate("time").ffill().bfill()
+        weather = weather.reindex(full_index).interpolate("time").ffill().bfill()
+        occ["outside_temp"] = weather["outside_temp"]
+    else:
+        occ["outside_temp"] = np.nan
+
+    if occ["outside_temp"].notna().any():
+        missing_temp = int(occ["outside_temp"].isna().sum())
+        if missing_temp:
+            median_temp = float(occ["outside_temp"].median())
+            LOGGER.info(
+                "Imputing %s missing outside_temp points with median %.3f.",
+                missing_temp,
+                median_temp,
+            )
+            occ["outside_temp"] = occ["outside_temp"].fillna(median_temp)
+
+    occ["is_occupied"] = occ["occupancy_count"] > 0
+    occ["hour"] = occ.index.hour
+    occ["day_of_week"] = occ.index.dayofweek
+    occ["is_weekend"] = occ["day_of_week"].isin([5, 6]).astype(int)
+
+    for lag in lag_periods:
+        occ[f"occupancy_lag_{lag}"] = occ["occupancy_count"].shift(lag)
+
+    if dropna_for_training:
+        lag_cols = [f"occupancy_lag_{lag}" for lag in lag_periods]
+        before = len(occ)
+        occ = occ.dropna(subset=lag_cols)
+        dropped = before - len(occ)
+        if dropped:
+            LOGGER.info("Dropped %s rows with lag-feature NaNs.", dropped)
+
+    return occ.reset_index()
 
 
 def merge_occupancy_hvac(
@@ -17,27 +185,43 @@ def merge_occupancy_hvac(
     how: str = "inner",
 ) -> pd.DataFrame:
     """
-    Merge occupancy and HVAC data on timestamp and zone.
-
-    Aligns occupancy counts with HVAC states/setpoints at a common frequency.
-    This merged dataset is the foundation for "opportunity for savings" analysis.
-
-    Args:
-        occ_df: Occupancy DataFrame with columns [timestamp, zone_id, occupancy_count].
-        hvac_df: HVAC DataFrame with columns [timestamp, zone_id, setpoint, state, ...].
-        freq: Target resampling frequency (e.g., "15min", "1H").
-        how: Merge type ("inner", "outer", "left", "right").
-
-    Returns:
-        Merged DataFrame with aligned occupancy and HVAC data.
-
-    TODO:
-        - Handle timezone differences between data sources
-        - Implement resampling/aggregation logic for different frequencies
-        - Add data quality flags for missing or interpolated values
+    Merge occupancy and HVAC data on timestamp and zone identifier.
     """
-    # TODO: Implement merging logic
-    raise NotImplementedError("Implement merge logic once data schemas are confirmed")
+    occ = normalize_occupancy(occ_df)
+    hvac_cols = list(hvac_df.columns)
+    hvac_timestamp_col = _pick_column(
+        hvac_cols, ["timestamp", "Timestamp", "time", "beginning"], "HVAC timestamp"
+    )
+    hvac_zone_col = _pick_column(
+        hvac_cols, ["zone_id", "space_id", "access_point", "ap"], "HVAC zone"
+    )
+
+    hvac = hvac_df.copy()
+    hvac[hvac_timestamp_col] = pd.to_datetime(hvac[hvac_timestamp_col], errors="coerce")
+    hvac[hvac_zone_col] = hvac[hvac_zone_col].astype(str)
+    hvac = hvac.dropna(subset=[hvac_timestamp_col, hvac_zone_col]).copy()
+    hvac = hvac.rename(
+        columns={
+            hvac_timestamp_col: "timestamp",
+            hvac_zone_col: "zone_id",
+        }
+    )
+
+    if "hvac_on" not in hvac.columns:
+        if "hvac_mode" in hvac.columns:
+            hvac["hvac_on"] = hvac["hvac_mode"].astype(str).str.lower().ne("off")
+        else:
+            hvac["hvac_on"] = True
+
+    occ["timestamp"] = occ["timestamp"].dt.floor(freq)
+    hvac["timestamp"] = hvac["timestamp"].dt.floor(freq)
+    occ = (
+        occ.groupby(["timestamp", "zone_id"], as_index=False)["occupancy_count"]
+        .mean()
+        .sort_values("timestamp")
+    )
+    hvac = hvac.groupby(["timestamp", "zone_id"], as_index=False).first().sort_values("timestamp")
+    return occ.merge(hvac, on=["timestamp", "zone_id"], how=how)
 
 
 def add_weather_features(
@@ -45,23 +229,15 @@ def add_weather_features(
     weather_df: pd.DataFrame,
 ) -> pd.DataFrame:
     """
-    Add weather features to the merged occupancy/HVAC dataset.
-
-    Weather conditions affect both occupancy patterns and HVAC energy usage.
-
-    Args:
-        df: Merged occupancy/HVAC DataFrame.
-        weather_df: Weather DataFrame with columns [timestamp, temperature, humidity, ...].
-
-    Returns:
-        DataFrame with weather features added.
-
-    TODO:
-        - Handle temporal alignment (weather data may be hourly, HVAC may be 15min)
-        - Add derived features (heating/cooling degree days, etc.)
+    Add aligned outside temperature to a timestamped dataframe.
     """
-    # TODO: Implement weather feature addition
-    raise NotImplementedError("Implement weather feature merging")
+    if "timestamp" not in df.columns:
+        raise ValueError("Input dataframe must contain 'timestamp'.")
+
+    base = df.copy()
+    base["timestamp"] = pd.to_datetime(base["timestamp"], errors="coerce")
+    weather = normalize_weather(weather_df)
+    return base.merge(weather, on="timestamp", how="left")
 
 
 def add_tou_features(
@@ -69,24 +245,34 @@ def add_tou_features(
     tou_df: pd.DataFrame,
 ) -> pd.DataFrame:
     """
-    Add time-of-use pricing features to the dataset.
+    Add simple TOU features by matching hour-of-day windows.
 
-    TOU rates are essential for computing cost savings from HVAC optimization.
-
-    Args:
-        df: DataFrame with timestamp column.
-        tou_df: TOU pricing DataFrame.
-
-    Returns:
-        DataFrame with TOU rate columns added.
-
-    TODO:
-        - Map timestamps to TOU periods (peak, off-peak, etc.)
-        - Handle holiday schedules
-        - Support multiple rate structures
+    Expected TOU columns:
+    - start_hour, end_hour, rate_kwh
     """
-    # TODO: Implement TOU feature addition
-    raise NotImplementedError("Implement TOU feature merging")
+    required = {"start_hour", "end_hour", "rate_kwh"}
+    if not required.issubset(set(tou_df.columns)):
+        raise ValueError(f"TOU dataframe must contain columns: {sorted(required)}")
+    if "timestamp" not in df.columns:
+        raise ValueError("Input dataframe must contain 'timestamp'.")
+
+    out = df.copy()
+    out["timestamp"] = pd.to_datetime(out["timestamp"], errors="coerce")
+    out["hour"] = out["timestamp"].dt.hour
+    out["tou_rate"] = np.nan
+
+    for _, row in tou_df.iterrows():
+        start = int(row["start_hour"])
+        end = int(row["end_hour"])
+        rate = float(row["rate_kwh"])
+        if start <= end:
+            mask = (out["hour"] >= start) & (out["hour"] < end)
+        else:
+            mask = (out["hour"] >= start) | (out["hour"] < end)
+        out.loc[mask, "tou_rate"] = rate
+
+    out["tou_rate"] = out["tou_rate"].ffill().bfill()
+    return out
 
 
 def engineer_features(
@@ -96,45 +282,26 @@ def engineer_features(
     lag_periods: Optional[List[int]] = None,
 ) -> pd.DataFrame:
     """
-    Engineer features for occupancy forecasting models.
-
-    Creates time-based features, lag features, and rolling statistics
-    that help forecasting models capture temporal patterns.
-
-    Args:
-        df: Input DataFrame with timestamp and occupancy columns.
-        include_time_features: Add hour, day of week, month, etc.
-        include_lag_features: Add lagged occupancy values.
-        lag_periods: List of lag periods (e.g., [1, 4, 96] for 15min data = 15min, 1hr, 1day).
-
-    Returns:
-        DataFrame with engineered features.
-
-    TODO:
-        - Add academic calendar features (semester, breaks, exam periods)
-        - Add building-specific event features if available
-        - Consider zone clustering features (similar rooms behave similarly)
+    Generic feature engineering helper for occupancy time series.
     """
     if lag_periods is None:
-        lag_periods = [1, 4, 96]  # 15min, 1hr, 1day for 15min frequency data
+        lag_periods = DEFAULT_LAG_PERIODS
 
     result = df.copy()
+    timestamp_col = "timestamp" if "timestamp" in result.columns else "ds"
+    target_col = "occupancy_count" if "occupancy_count" in result.columns else "y"
+
+    result[timestamp_col] = pd.to_datetime(result[timestamp_col], errors="coerce")
+    result = result.sort_values(timestamp_col).reset_index(drop=True)
 
     if include_time_features:
-        # TODO: Implement time feature extraction
-        # result['hour'] = result['timestamp'].dt.hour
-        # result['day_of_week'] = result['timestamp'].dt.dayofweek
-        # result['is_weekend'] = result['day_of_week'].isin([5, 6])
-        # result['month'] = result['timestamp'].dt.month
-        pass
+        result["hour"] = result[timestamp_col].dt.hour
+        result["day_of_week"] = result[timestamp_col].dt.dayofweek
+        result["is_weekend"] = result["day_of_week"].isin([5, 6]).astype(int)
 
-    if include_lag_features:
-        # TODO: Implement lag feature creation
-        # for lag in lag_periods:
-        #     result[f'occupancy_lag_{lag}'] = result.groupby('zone_id')['occupancy_count'].shift(lag)
-        pass
-
-    # TODO: Add rolling statistics (mean, std over past N periods)
+    if include_lag_features and target_col in result.columns:
+        for lag in lag_periods:
+            result[f"{target_col}_lag_{lag}"] = result[target_col].shift(lag)
 
     return result
 
@@ -146,33 +313,21 @@ def compute_opportunity_for_savings(
     energy_col: Optional[str] = "energy_kwh",
 ) -> pd.DataFrame:
     """
-    Identify "opportunity for savings" periods in historical data.
-
-    An "opportunity" is defined as a period where:
-    - Occupancy is zero (or below threshold)
-    - HVAC is actively running (consuming energy)
-
-    This analysis quantifies potential energy and cost savings.
-
-    Args:
-        df: Merged occupancy/HVAC DataFrame.
-        occupancy_col: Column name for occupancy count.
-        hvac_state_col: Column name for HVAC on/off state.
-        energy_col: Column name for energy consumption (optional).
-
-    Returns:
-        DataFrame with opportunity flags and potential savings metrics.
-
-    TODO:
-        - Define occupancy threshold (zero vs. low occupancy)
-        - Account for HVAC pre-conditioning needs (some pre-heating/cooling is OK)
-        - Add comfort constraint considerations
-        - Integrate TOU pricing for cost savings estimation
+    Identify historical opportunities for savings:
+    occupancy <= 0 while HVAC is on.
     """
+    if occupancy_col not in df.columns:
+        raise ValueError(f"Missing occupancy column: {occupancy_col}")
+    if hvac_state_col not in df.columns:
+        raise ValueError(f"Missing HVAC state column: {hvac_state_col}")
+
     result = df.copy()
+    result[occupancy_col] = pd.to_numeric(result[occupancy_col], errors="coerce").fillna(0)
+    hvac_on = result[hvac_state_col].astype(bool)
+    result["is_opportunity"] = (result[occupancy_col] <= 0) & hvac_on
 
-    # TODO: Implement opportunity detection logic
-    # result['is_opportunity'] = (result[occupancy_col] == 0) & (result[hvac_state_col] == True)
-    # result['potential_energy_savings'] = result['is_opportunity'] * result[energy_col]
+    if energy_col and energy_col in result.columns:
+        energy = pd.to_numeric(result[energy_col], errors="coerce").fillna(0.0)
+        result["potential_energy_savings"] = np.where(result["is_opportunity"], energy, 0.0)
 
-    raise NotImplementedError("Implement opportunity for savings calculation")
+    return result

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,12 +1,16 @@
 """Forecasting models for occupancy prediction."""
 
-from .prophet_baseline import ProphetOccupancyModel
+from .prophet_baseline import ProphetOccupancyModel, predict_occupancy
 from .transformer_baseline import TransformerOccupancyModel
-from .xgBoost import occupancy_predictor
+try:
+    from .xgBoost import occupancy_predictor
+except Exception:  # pragma: no cover - optional dependency (xgboost)
+    occupancy_predictor = None
 
 
 __all__ = [
     "ProphetOccupancyModel",
+    "predict_occupancy",
     "TransformerOccupancyModel",
     "occupancy_predictor",
 ]

--- a/src/models/prophet_baseline.py
+++ b/src/models/prophet_baseline.py
@@ -1,32 +1,37 @@
 """
 Prophet-based baseline model for occupancy forecasting.
 
-Uses Facebook Prophet for time-series forecasting of building occupancy.
-Prophet handles seasonality (daily, weekly, yearly) and holidays well,
-making it a good baseline for campus building occupancy patterns.
+If Prophet is unavailable in the runtime environment, this module falls back
+to a deterministic seasonal naive model so the pipeline remains runnable.
 """
 
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import numpy as np
 import pandas as pd
-from typing import Optional, Dict, Any
+
+try:
+    from prophet import Prophet
+except ImportError:  # pragma: no cover - depends on runtime environment
+    Prophet = None
+
+from src.data.preprocess import prepare_occupancy_forecast_dataset
+
+
+@dataclass
+class _SeasonalProfile:
+    profile: pd.Series
+    global_mean: float
 
 
 class ProphetOccupancyModel:
     """
-    Prophet-based occupancy forecasting model.
-
-    Wraps Facebook Prophet to predict future occupancy for a given zone,
-    capturing daily patterns (class schedules), weekly patterns (weekdays vs weekends),
-    and longer-term seasonality (academic calendar).
-
-    Attributes:
-        model: The underlying Prophet model instance.
-        zone_id: The zone/room this model is trained for.
-        freq: Forecast frequency (e.g., "15min", "1H").
-
-    TODO:
-        - Add support for external regressors (weather, events)
-        - Implement cross-validation for hyperparameter tuning
-        - Add academic calendar as custom seasonality or holidays
+    Occupancy forecasting model with Prophet primary backend and
+    seasonal-naive fallback backend.
     """
 
     def __init__(
@@ -35,91 +40,295 @@ class ProphetOccupancyModel:
         freq: str = "15min",
         **prophet_kwargs: Dict[str, Any],
     ):
-        """
-        Initialize the Prophet occupancy model.
-
-        Args:
-            zone_id: Identifier for the zone/room being modeled.
-            freq: Forecast frequency.
-            **prophet_kwargs: Additional arguments passed to Prophet().
-        """
         self.zone_id = zone_id
         self.freq = freq
         self.prophet_kwargs = prophet_kwargs
+
         self.model = None
+        self.backend = "unfitted"
+        self._uses_temp = False
+        self._fitted_df: Optional[pd.DataFrame] = None
+        self._seasonal: Optional[_SeasonalProfile] = None
+        self._temp_median: Optional[float] = None
+
+    @staticmethod
+    def _normalize_fit_df(df: pd.DataFrame) -> pd.DataFrame:
+        if "ds" not in df.columns or "y" not in df.columns:
+            raise ValueError("Fit dataframe must contain columns ['ds', 'y'].")
+
+        out = df.copy()
+        out["ds"] = pd.to_datetime(out["ds"], errors="coerce")
+        out["y"] = pd.to_numeric(out["y"], errors="coerce")
+        if "outside_temp" in out.columns:
+            out["outside_temp"] = pd.to_numeric(out["outside_temp"], errors="coerce")
+
+        out = out.dropna(subset=["ds", "y"]).sort_values("ds").reset_index(drop=True)
+        if out.empty:
+            raise ValueError("No valid training rows after parsing ['ds', 'y'].")
+        return out
+
+    @staticmethod
+    def _slot_key(ts: pd.Series) -> pd.MultiIndex:
+        minutes = ts.dt.hour * 60 + ts.dt.minute
+        return pd.MultiIndex.from_arrays([ts.dt.dayofweek, minutes], names=["dow", "slot"])
+
+    def _build_seasonal_fallback(self, df: pd.DataFrame) -> None:
+        keyed = df.copy()
+        keyed["dow"] = keyed["ds"].dt.dayofweek
+        keyed["slot"] = keyed["ds"].dt.hour * 60 + keyed["ds"].dt.minute
+        profile = keyed.groupby(["dow", "slot"])["y"].mean()
+        global_mean = float(keyed["y"].mean()) if len(keyed) else 0.0
+        self._seasonal = _SeasonalProfile(profile=profile, global_mean=global_mean)
+        self.backend = "seasonal_naive"
 
     def fit(self, df: pd.DataFrame) -> "ProphetOccupancyModel":
-        """
-        Fit the Prophet model on historical occupancy data.
+        train = self._normalize_fit_df(df)
+        self._fitted_df = train
+        self._uses_temp = "outside_temp" in train.columns and train["outside_temp"].notna().any()
+        self._temp_median = (
+            float(train["outside_temp"].median()) if self._uses_temp else None
+        )
 
-        Args:
-            df: DataFrame with columns ['ds', 'y'] where:
-                - ds: datetime timestamp
-                - y: occupancy count
+        if Prophet is None:
+            self._build_seasonal_fallback(train)
+            self.model = None
+            return self
 
-        Returns:
-            self (fitted model)
+        defaults: Dict[str, Any] = {
+            "daily_seasonality": True,
+            "weekly_seasonality": True,
+            "yearly_seasonality": False,
+        }
+        defaults.update(self.prophet_kwargs)
 
-        TODO:
-            - Implement actual Prophet fitting
-            - Add data validation
-            - Configure seasonalities for campus patterns
-        """
-        # TODO: Implement Prophet model fitting
-        # from prophet import Prophet
-        # self.model = Prophet(**self.prophet_kwargs)
-        # self.model.fit(df)
-        raise NotImplementedError("Implement Prophet model fitting")
+        model = Prophet(**defaults)
+        fit_cols = ["ds", "y"]
+        if self._uses_temp:
+            model.add_regressor("outside_temp")
+            fit_cols.append("outside_temp")
+            train = train.copy()
+            train["outside_temp"] = train["outside_temp"].fillna(self._temp_median)
+
+        model.fit(train[fit_cols])
+        self.model = model
+        self.backend = "prophet"
+        return self
+
+    @staticmethod
+    def _normalize_future_df(future_df: pd.DataFrame) -> pd.DataFrame:
+        if "ds" not in future_df.columns:
+            raise ValueError("Future dataframe must include 'ds'.")
+
+        out = future_df.copy()
+        out["ds"] = pd.to_datetime(out["ds"], errors="coerce")
+        if "outside_temp" in out.columns:
+            out["outside_temp"] = pd.to_numeric(out["outside_temp"], errors="coerce")
+        out = out.dropna(subset=["ds"]).sort_values("ds").reset_index(drop=True)
+        if out.empty:
+            raise ValueError("No valid future rows after datetime parsing.")
+        return out
+
+    def _fill_missing_future_temp(self, future_df: pd.DataFrame) -> pd.DataFrame:
+        out = future_df.copy()
+        if not self._uses_temp:
+            return out
+        if "outside_temp" not in out.columns:
+            out["outside_temp"] = self._temp_median
+        else:
+            out["outside_temp"] = out["outside_temp"].fillna(self._temp_median)
+        return out
+
+    @staticmethod
+    def _post_process(forecast_df: pd.DataFrame) -> pd.DataFrame:
+        out = forecast_df.copy()
+        for col in ["yhat", "yhat_lower", "yhat_upper"]:
+            out[col] = pd.to_numeric(out[col], errors="coerce").fillna(0.0).clip(lower=0.0)
+        out["pred_occupancy_count"] = out["yhat"]
+        out["pred_is_occupied"] = out["pred_occupancy_count"] >= 1.0
+        return out
+
+    def _predict_core(self, future_df: pd.DataFrame) -> pd.DataFrame:
+        if self.backend == "unfitted":
+            raise ValueError("Model must be fitted before prediction.")
+
+        future = self._fill_missing_future_temp(self._normalize_future_df(future_df))
+
+        if self.backend == "prophet":
+            assert self.model is not None
+            pred_cols = ["ds"] + (["outside_temp"] if self._uses_temp else [])
+            forecast = self.model.predict(future[pred_cols])
+            out = forecast[["ds", "yhat", "yhat_lower", "yhat_upper"]].copy()
+            return self._post_process(out)
+
+        assert self._seasonal is not None
+        keys = self._slot_key(future["ds"])
+        yhat = np.array(
+            [self._seasonal.profile.get(key, self._seasonal.global_mean) for key in keys],
+            dtype=float,
+        )
+        out = pd.DataFrame(
+            {
+                "ds": future["ds"],
+                "yhat": yhat,
+                "yhat_lower": yhat,
+                "yhat_upper": yhat,
+            }
+        )
+        return self._post_process(out)
 
     def predict(
         self,
         periods: int,
         include_history: bool = False,
     ) -> pd.DataFrame:
-        """
-        Generate occupancy forecasts for future periods.
+        if self._fitted_df is None:
+            raise ValueError("Model must be fitted before prediction.")
+        if periods <= 0:
+            raise ValueError("periods must be > 0")
 
-        Args:
-            periods: Number of future periods to forecast.
-            include_history: Whether to include historical fitted values.
+        last_ds = self._fitted_df["ds"].max()
+        future_index = pd.date_range(
+            start=last_ds + pd.tseries.frequencies.to_offset(self.freq),
+            periods=periods,
+            freq=self.freq,
+        )
+        future = pd.DataFrame({"ds": future_index})
 
-        Returns:
-            DataFrame with columns ['ds', 'yhat', 'yhat_lower', 'yhat_upper'].
+        if include_history:
+            history = self._fitted_df[["ds"]].copy()
+            if self._uses_temp and "outside_temp" in self._fitted_df.columns:
+                history["outside_temp"] = self._fitted_df["outside_temp"]
+            if self._uses_temp and "outside_temp" not in future.columns:
+                future["outside_temp"] = self._temp_median
+            future = pd.concat([history, future], ignore_index=True)
 
-        TODO:
-            - Implement prediction logic
-            - Add uncertainty intervals
-            - Post-process predictions (e.g., clip negative values to 0)
-        """
-        if self.model is None:
-            raise ValueError("Model must be fitted before prediction")
+        return self._predict_core(future)
 
-        # TODO: Implement prediction
-        # future = self.model.make_future_dataframe(periods=periods, freq=self.freq)
-        # forecast = self.model.predict(future)
-        raise NotImplementedError("Implement Prophet prediction")
+    def predict_date_range(
+        self,
+        start_ts: datetime | str,
+        end_ts: datetime | str,
+        weather_future_df: Optional[pd.DataFrame] = None,
+    ) -> pd.DataFrame:
+        start = pd.Timestamp(start_ts)
+        end = pd.Timestamp(end_ts)
+        if end < start:
+            raise ValueError("end_ts must be >= start_ts")
+
+        index = pd.date_range(start=start, end=end, freq=self.freq)
+        future = pd.DataFrame({"ds": index})
+
+        if weather_future_df is not None and len(weather_future_df):
+            weather = weather_future_df.copy()
+            if "timestamp" in weather.columns and "ds" not in weather.columns:
+                weather = weather.rename(columns={"timestamp": "ds"})
+            if "temperature" in weather.columns and "outside_temp" not in weather.columns:
+                weather = weather.rename(columns={"temperature": "outside_temp"})
+            weather = weather[["ds", "outside_temp"]].copy()
+            weather["ds"] = pd.to_datetime(weather["ds"], errors="coerce")
+            weather["outside_temp"] = pd.to_numeric(weather["outside_temp"], errors="coerce")
+            future = future.merge(weather, on="ds", how="left")
+
+        return self._predict_core(future)
+
+    def predict_dataframe(self, future_df: pd.DataFrame) -> pd.DataFrame:
+        return self._predict_core(future_df)
 
     def evaluate(
         self,
         test_df: pd.DataFrame,
         metrics: Optional[list] = None,
     ) -> Dict[str, float]:
-        """
-        Evaluate model performance on test data.
-
-        Args:
-            test_df: Test DataFrame with columns ['ds', 'y'].
-            metrics: List of metrics to compute (default: MAE, RMSE, MAPE).
-
-        Returns:
-            Dictionary of metric names to values.
-
-        TODO:
-            - Implement evaluation metrics
-            - Add occupancy-specific metrics (e.g., accuracy at zero detection)
-        """
         if metrics is None:
-            metrics = ["mae", "rmse", "mape"]
+            metrics = ["binary_accuracy", "precision", "recall", "f1", "mae"]
+        if "ds" not in test_df.columns or "y" not in test_df.columns:
+            raise ValueError("test_df must contain ['ds', 'y'].")
 
-        # TODO: Implement evaluation
-        raise NotImplementedError("Implement model evaluation")
+        eval_df = test_df.copy()
+        eval_df["ds"] = pd.to_datetime(eval_df["ds"], errors="coerce")
+        eval_df["y"] = pd.to_numeric(eval_df["y"], errors="coerce")
+        eval_df = eval_df.dropna(subset=["ds", "y"]).sort_values("ds")
+
+        predict_cols = ["ds"] + (["outside_temp"] if "outside_temp" in eval_df.columns else [])
+        forecast = self.predict_dataframe(eval_df[predict_cols])
+        merged = eval_df.merge(
+            forecast[["ds", "pred_occupancy_count", "pred_is_occupied"]],
+            on="ds",
+            how="inner",
+        )
+        if merged.empty:
+            raise ValueError("No overlapping rows between test data and predictions.")
+
+        y_true = merged["y"].to_numpy(dtype=float)
+        y_pred = merged["pred_occupancy_count"].to_numpy(dtype=float)
+        y_true_bin = y_true > 0
+        y_pred_bin = merged["pred_is_occupied"].astype(bool).to_numpy()
+
+        tp = int(np.sum(y_true_bin & y_pred_bin))
+        tn = int(np.sum(~y_true_bin & ~y_pred_bin))
+        fp = int(np.sum(~y_true_bin & y_pred_bin))
+        fn = int(np.sum(y_true_bin & ~y_pred_bin))
+
+        total = max(len(merged), 1)
+        accuracy = (tp + tn) / total
+        precision = tp / (tp + fp) if (tp + fp) else 0.0
+        recall = tp / (tp + fn) if (tp + fn) else 0.0
+        f1 = 0.0 if (precision + recall) == 0 else 2 * precision * recall / (precision + recall)
+        mae = float(np.mean(np.abs(y_true - y_pred)))
+
+        all_metrics = {
+            "binary_accuracy": float(accuracy),
+            "precision": float(precision),
+            "recall": float(recall),
+            "f1": float(f1),
+            "mae": float(mae),
+            "n_eval_rows": float(len(merged)),
+        }
+        return {name: all_metrics[name] for name in metrics if name in all_metrics}
+
+
+def predict_occupancy(
+    zone_id: str,
+    start_ts: datetime | str,
+    end_ts: datetime | str,
+    freq: str = "15min",
+    model: Optional[ProphetOccupancyModel] = None,
+    historical_df: Optional[pd.DataFrame] = None,
+    weather_history_df: Optional[pd.DataFrame] = None,
+    weather_future_df: Optional[pd.DataFrame] = None,
+    train_ratio: float = 0.8,
+    **prophet_kwargs: Dict[str, Any],
+) -> pd.DataFrame:
+    """
+    Service-style interface for single-zone occupancy prediction.
+
+    If model is not provided, the function trains a model from historical_df.
+    """
+    if model is None:
+        if historical_df is None:
+            raise ValueError("historical_df is required when model is not provided.")
+        ds = prepare_occupancy_forecast_dataset(
+            occ_df=historical_df,
+            weather_df=weather_history_df,
+            zone_id=zone_id,
+            freq=freq,
+            dropna_for_training=True,
+        )
+        fit_df = ds.rename(columns={"timestamp": "ds", "occupancy_count": "y"})[
+            ["ds", "y", "outside_temp"]
+        ].copy()
+        split_idx = int(len(fit_df) * float(train_ratio))
+        if split_idx < 1:
+            raise ValueError("Not enough rows to train model.")
+
+        model = ProphetOccupancyModel(zone_id=zone_id, freq=freq, **prophet_kwargs)
+        model.fit(fit_df.iloc[:split_idx].reset_index(drop=True))
+
+    forecast = model.predict_date_range(
+        start_ts=start_ts,
+        end_ts=end_ts,
+        weather_future_df=weather_future_df,
+    )
+    out = forecast.rename(columns={"ds": "timestamp"}).copy()
+    out["zone_id"] = str(zone_id)
+    return out[["timestamp", "zone_id", "pred_occupancy_count", "pred_is_occupied"]]

--- a/src/viz/__init__.py
+++ b/src/viz/__init__.py
@@ -1,12 +1,31 @@
 """Visualization and dashboard utilities for HVAC occupancy analysis."""
 
-from .dashboards import (
-    plot_daily_opportunity_for_savings,
-    plot_occupancy_over_time,
-    plot_example_day_timeline,
-    plot_occupancy_heatmap,
-    plot_savings_summary,
+from .dashboard_data import (
+    fetch_hvac_comfort_summary,
+    fetch_hvac_daily,
+    fetch_hvac_hourly,
+    fetch_hvac_kpis,
+    fetch_hvac_zone_stats,
+    fetch_occupancy_daily,
+    fetch_occupancy_heatmap,
+    fetch_occupancy_kpis,
+    fetch_occupancy_space_stats,
 )
+from .dashboard_insights import derive_hvac_insights, derive_occupancy_insights
+try:
+    from .dashboards import (
+        plot_daily_opportunity_for_savings,
+        plot_occupancy_over_time,
+        plot_example_day_timeline,
+        plot_occupancy_heatmap,
+        plot_savings_summary,
+    )
+except ModuleNotFoundError:  # pragma: no cover - optional visualization deps
+    plot_daily_opportunity_for_savings = None
+    plot_occupancy_over_time = None
+    plot_example_day_timeline = None
+    plot_occupancy_heatmap = None
+    plot_savings_summary = None
 
 __all__ = [
     "plot_daily_opportunity_for_savings",
@@ -14,4 +33,15 @@ __all__ = [
     "plot_example_day_timeline",
     "plot_occupancy_heatmap",
     "plot_savings_summary",
+    "fetch_occupancy_kpis",
+    "fetch_occupancy_daily",
+    "fetch_occupancy_heatmap",
+    "fetch_occupancy_space_stats",
+    "fetch_hvac_kpis",
+    "fetch_hvac_daily",
+    "fetch_hvac_hourly",
+    "fetch_hvac_zone_stats",
+    "fetch_hvac_comfort_summary",
+    "derive_occupancy_insights",
+    "derive_hvac_insights",
 ]

--- a/src/viz/dashboard_data.py
+++ b/src/viz/dashboard_data.py
@@ -1,0 +1,288 @@
+"""
+PostgreSQL query helpers for the Streamlit HVAC/occupancy dashboard.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from pathlib import Path
+import sys
+from typing import List, Optional, Sequence
+
+# Make `src.*` imports work even when module is run from outside repo root.
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import pandas as pd
+
+from src.data import get_postgres_connection
+
+IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_identifier(identifier: str, label: str) -> None:
+    if not IDENTIFIER_RE.match(identifier):
+        raise ValueError(f"Invalid {label}: {identifier!r}")
+
+
+def _to_datetime(value: Optional[datetime | str]) -> Optional[datetime]:
+    if value is None:
+        return None
+    ts = pd.Timestamp(value)
+    if pd.isna(ts):
+        return None
+    return ts.to_pydatetime()
+
+
+def _build_time_filter(
+    column_name: str,
+    start_ts: Optional[datetime | str],
+    end_ts: Optional[datetime | str],
+) -> tuple[str, List[datetime]]:
+    start_dt = _to_datetime(start_ts)
+    end_dt = _to_datetime(end_ts)
+    if start_dt is not None and end_dt is not None and start_dt > end_dt:
+        raise ValueError("start_ts must be <= end_ts")
+
+    clauses: List[str] = []
+    params: List[datetime] = []
+    if start_dt is not None:
+        clauses.append(f"{column_name} >= %s")
+        params.append(start_dt)
+    if end_dt is not None:
+        clauses.append(f"{column_name} <= %s")
+        params.append(end_dt)
+
+    return (" AND ".join(clauses) if clauses else "TRUE"), params
+
+
+def _query_dataframe(
+    query: str,
+    params: Optional[Sequence] = None,
+    env_path: str = ".env",
+) -> pd.DataFrame:
+    with get_postgres_connection(env_path=env_path) as conn:
+        with conn.cursor() as cur:
+            cur.execute(query, params if params is not None else [])
+            columns = [desc[0] for desc in cur.description]
+            rows = cur.fetchall()
+    return pd.DataFrame(rows, columns=columns)
+
+
+def fetch_occupancy_kpis(
+    schema: str = "public",
+    env_path: str = ".env",
+    start_ts: Optional[datetime | str] = None,
+    end_ts: Optional[datetime | str] = None,
+) -> pd.DataFrame:
+    _validate_identifier(schema, "schema")
+    where_sql, params = _build_time_filter("beginning", start_ts, end_ts)
+    query = f"""
+    SELECT
+      COUNT(*)::bigint AS rows,
+      COUNT(DISTINCT space_id)::int AS spaces,
+      MIN(beginning) AS min_ts,
+      MAX(beginning) AS max_ts,
+      ROUND(AVG(occupancy)::numeric, 2) AS avg_occ,
+      ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY occupancy)::numeric, 2) AS median_occ,
+      MAX(occupancy) AS peak_occ
+    FROM "{schema}"."space_occupancy"
+    WHERE {where_sql};
+    """
+    return _query_dataframe(query=query, params=params, env_path=env_path)
+
+
+def fetch_occupancy_daily(
+    schema: str = "public",
+    env_path: str = ".env",
+    start_ts: Optional[datetime | str] = None,
+    end_ts: Optional[datetime | str] = None,
+) -> pd.DataFrame:
+    _validate_identifier(schema, "schema")
+    where_sql, params = _build_time_filter("beginning", start_ts, end_ts)
+    query = f"""
+    SELECT
+      DATE(beginning) AS day,
+      ROUND(AVG(occupancy)::numeric, 2) AS avg_occ,
+      MAX(occupancy) AS peak_occ,
+      COUNT(*)::bigint AS samples
+    FROM "{schema}"."space_occupancy"
+    WHERE {where_sql}
+    GROUP BY DATE(beginning)
+    ORDER BY day;
+    """
+    return _query_dataframe(query=query, params=params, env_path=env_path)
+
+
+def fetch_occupancy_heatmap(
+    schema: str = "public",
+    env_path: str = ".env",
+    start_ts: Optional[datetime | str] = None,
+    end_ts: Optional[datetime | str] = None,
+) -> pd.DataFrame:
+    _validate_identifier(schema, "schema")
+    where_sql, params = _build_time_filter("beginning", start_ts, end_ts)
+    query = f"""
+    SELECT
+      EXTRACT(DOW FROM beginning)::int AS day_of_week,
+      EXTRACT(HOUR FROM beginning)::int AS hour_of_day,
+      ROUND(AVG(occupancy)::numeric, 2) AS avg_occ,
+      COUNT(*)::bigint AS samples
+    FROM "{schema}"."space_occupancy"
+    WHERE {where_sql}
+    GROUP BY 1, 2
+    ORDER BY 1, 2;
+    """
+    return _query_dataframe(query=query, params=params, env_path=env_path)
+
+
+def fetch_occupancy_space_stats(
+    schema: str = "public",
+    env_path: str = ".env",
+    start_ts: Optional[datetime | str] = None,
+    end_ts: Optional[datetime | str] = None,
+) -> pd.DataFrame:
+    _validate_identifier(schema, "schema")
+    where_sql, params = _build_time_filter("o.beginning", start_ts, end_ts)
+    query = f"""
+    SELECT
+      o.space_id::text AS space_id,
+      COALESCE(s.building_room, s.space_name, '(unknown)') AS space_label,
+      ROUND(AVG(o.occupancy)::numeric, 2) AS avg_occ,
+      MAX(o.occupancy) AS peak_occ,
+      COUNT(*)::bigint AS samples
+    FROM "{schema}"."space_occupancy" o
+    LEFT JOIN "{schema}"."space" s
+      ON s.space_id = o.space_id
+    WHERE {where_sql}
+    GROUP BY o.space_id, space_label
+    ORDER BY avg_occ DESC, samples DESC;
+    """
+    return _query_dataframe(query=query, params=params, env_path=env_path)
+
+
+def fetch_hvac_kpis(
+    schema: str = "public",
+    env_path: str = ".env",
+    start_ts: Optional[datetime | str] = None,
+    end_ts: Optional[datetime | str] = None,
+) -> pd.DataFrame:
+    _validate_identifier(schema, "schema")
+    where_sql, params = _build_time_filter("timestamp", start_ts, end_ts)
+    query = f"""
+    SELECT
+      COUNT(*)::bigint AS rows,
+      COUNT(DISTINCT space_id)::int AS zones,
+      MIN(timestamp) AS min_ts,
+      MAX(timestamp) AS max_ts,
+      ROUND(AVG(zone_temp)::numeric, 2) AS avg_temp,
+      ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY zone_temp)::numeric, 2) AS median_temp,
+      ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY zone_temp)::numeric, 2) AS p95_temp
+    FROM "{schema}"."hvac"
+    WHERE {where_sql};
+    """
+    return _query_dataframe(query=query, params=params, env_path=env_path)
+
+
+def fetch_hvac_daily(
+    schema: str = "public",
+    env_path: str = ".env",
+    start_ts: Optional[datetime | str] = None,
+    end_ts: Optional[datetime | str] = None,
+) -> pd.DataFrame:
+    _validate_identifier(schema, "schema")
+    where_sql, params = _build_time_filter("timestamp", start_ts, end_ts)
+    query = f"""
+    SELECT
+      DATE(timestamp) AS day,
+      ROUND(AVG(zone_temp)::numeric, 2) AS avg_temp,
+      ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY zone_temp)::numeric, 2) AS p95_temp,
+      COUNT(*)::bigint AS samples
+    FROM "{schema}"."hvac"
+    WHERE {where_sql}
+    GROUP BY DATE(timestamp)
+    ORDER BY day;
+    """
+    return _query_dataframe(query=query, params=params, env_path=env_path)
+
+
+def fetch_hvac_hourly(
+    schema: str = "public",
+    env_path: str = ".env",
+    start_ts: Optional[datetime | str] = None,
+    end_ts: Optional[datetime | str] = None,
+) -> pd.DataFrame:
+    _validate_identifier(schema, "schema")
+    where_sql, params = _build_time_filter("timestamp", start_ts, end_ts)
+    query = f"""
+    SELECT
+      EXTRACT(HOUR FROM timestamp)::int AS hour_of_day,
+      ROUND(AVG(zone_temp)::numeric, 2) AS avg_temp,
+      ROUND(PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY zone_temp)::numeric, 2) AS p90_temp,
+      COUNT(*)::bigint AS samples
+    FROM "{schema}"."hvac"
+    WHERE {where_sql}
+    GROUP BY 1
+    ORDER BY 1;
+    """
+    return _query_dataframe(query=query, params=params, env_path=env_path)
+
+
+def fetch_hvac_zone_stats(
+    schema: str = "public",
+    env_path: str = ".env",
+    comfort_low: float = 70.0,
+    comfort_high: float = 76.0,
+    start_ts: Optional[datetime | str] = None,
+    end_ts: Optional[datetime | str] = None,
+) -> pd.DataFrame:
+    _validate_identifier(schema, "schema")
+    where_sql, time_params = _build_time_filter("timestamp", start_ts, end_ts)
+    params: List[object] = [comfort_low, comfort_high]
+    params.extend(time_params)
+    query = f"""
+    SELECT
+      space_id,
+      ROUND(AVG(zone_temp)::numeric, 2) AS avg_temp,
+      ROUND(STDDEV_POP(zone_temp)::numeric, 2) AS std_temp,
+      ROUND(MIN(zone_temp)::numeric, 2) AS min_temp,
+      ROUND(MAX(zone_temp)::numeric, 2) AS max_temp,
+      ROUND(
+        100.0 * AVG(CASE WHEN zone_temp < %s OR zone_temp > %s THEN 1.0 ELSE 0.0 END)::numeric,
+        2
+      ) AS comfort_exceedance_pct,
+      COUNT(*)::bigint AS samples
+    FROM "{schema}"."hvac"
+    WHERE {where_sql}
+    GROUP BY space_id
+    ORDER BY avg_temp DESC, samples DESC;
+    """
+    return _query_dataframe(query=query, params=params, env_path=env_path)
+
+
+def fetch_hvac_comfort_summary(
+    schema: str = "public",
+    env_path: str = ".env",
+    comfort_low: float = 70.0,
+    comfort_high: float = 76.0,
+    start_ts: Optional[datetime | str] = None,
+    end_ts: Optional[datetime | str] = None,
+) -> pd.DataFrame:
+    _validate_identifier(schema, "schema")
+    where_sql, time_params = _build_time_filter("timestamp", start_ts, end_ts)
+    params: List[object] = [comfort_low, comfort_high, comfort_low, comfort_high]
+    params.extend(time_params)
+    query = f"""
+    SELECT
+      ROUND(100.0 * AVG(CASE WHEN zone_temp < %s THEN 1.0 ELSE 0.0 END)::numeric, 2) AS below_band_pct,
+      ROUND(100.0 * AVG(CASE WHEN zone_temp > %s THEN 1.0 ELSE 0.0 END)::numeric, 2) AS above_band_pct,
+      ROUND(
+        100.0 * AVG(CASE WHEN zone_temp < %s OR zone_temp > %s THEN 1.0 ELSE 0.0 END)::numeric,
+        2
+      ) AS out_of_band_pct
+    FROM "{schema}"."hvac"
+    WHERE {where_sql};
+    """
+    return _query_dataframe(query=query, params=params, env_path=env_path)

--- a/src/viz/dashboard_insights.py
+++ b/src/viz/dashboard_insights.py
@@ -1,0 +1,137 @@
+"""
+Derived stakeholder-facing insight helpers for dashboard narrative cards.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import pandas as pd
+
+POSTGRES_DOW_LABELS = {
+    0: "Sunday",
+    1: "Monday",
+    2: "Tuesday",
+    3: "Wednesday",
+    4: "Thursday",
+    5: "Friday",
+    6: "Saturday",
+}
+
+
+def _fmt_number(value: float | int | None, decimals: int = 2) -> str:
+    if value is None or pd.isna(value):
+        return "N/A"
+    return f"{float(value):,.{decimals}f}"
+
+
+def derive_occupancy_insights(
+    heatmap_df: pd.DataFrame,
+    space_stats_df: pd.DataFrame,
+    low_space_count: int = 3,
+) -> Dict[str, object]:
+    if heatmap_df.empty and space_stats_df.empty:
+        return {
+            "busiest_day": "N/A",
+            "busiest_hour": "N/A",
+            "busiest_hour_avg_occ": "N/A",
+            "highest_util_space": "N/A",
+            "highest_util_avg_occ": "N/A",
+            "low_util_spaces": [],
+        }
+
+    busiest_day = "N/A"
+    busiest_hour = "N/A"
+    busiest_hour_avg_occ = "N/A"
+    if not heatmap_df.empty:
+        heat = heatmap_df.copy()
+        heat["avg_occ"] = pd.to_numeric(heat["avg_occ"], errors="coerce")
+        heat = heat.dropna(subset=["avg_occ"])
+        if not heat.empty:
+            by_day = (
+                heat.groupby("day_of_week", as_index=False)["avg_occ"]
+                .mean()
+                .sort_values("avg_occ", ascending=False)
+            )
+            if not by_day.empty:
+                busiest_day = POSTGRES_DOW_LABELS.get(int(by_day.iloc[0]["day_of_week"]), "N/A")
+
+            busiest_cell = heat.sort_values("avg_occ", ascending=False).iloc[0]
+            hour = int(busiest_cell["hour_of_day"])
+            busiest_hour = f"{hour:02d}:00"
+            busiest_hour_avg_occ = _fmt_number(float(busiest_cell["avg_occ"]), decimals=2)
+
+    highest_util_space = "N/A"
+    highest_util_avg_occ = "N/A"
+    low_util_spaces: List[str] = []
+    if not space_stats_df.empty:
+        spaces = space_stats_df.copy()
+        spaces["avg_occ"] = pd.to_numeric(spaces["avg_occ"], errors="coerce")
+        spaces = spaces.dropna(subset=["avg_occ"]).sort_values("avg_occ", ascending=False)
+        if not spaces.empty:
+            top_row = spaces.iloc[0]
+            highest_util_space = str(top_row["space_label"])
+            highest_util_avg_occ = _fmt_number(float(top_row["avg_occ"]), decimals=2)
+
+            low_rows = (
+                spaces.sort_values("avg_occ", ascending=True)
+                .head(low_space_count)["space_label"]
+                .astype(str)
+                .tolist()
+            )
+            low_util_spaces = low_rows
+
+    return {
+        "busiest_day": busiest_day,
+        "busiest_hour": busiest_hour,
+        "busiest_hour_avg_occ": busiest_hour_avg_occ,
+        "highest_util_space": highest_util_space,
+        "highest_util_avg_occ": highest_util_avg_occ,
+        "low_util_spaces": low_util_spaces,
+    }
+
+
+def derive_hvac_insights(
+    zone_stats_df: pd.DataFrame,
+    comfort_summary_df: pd.DataFrame,
+) -> Dict[str, str]:
+    if zone_stats_df.empty:
+        return {
+            "high_variability_zone": "N/A",
+            "high_variability_std_temp": "N/A",
+            "hottest_zone": "N/A",
+            "hottest_zone_avg_temp": "N/A",
+            "coldest_zone": "N/A",
+            "coldest_zone_avg_temp": "N/A",
+            "overall_out_of_band_pct": "N/A",
+        }
+
+    zones = zone_stats_df.copy()
+    zones["std_temp"] = pd.to_numeric(zones["std_temp"], errors="coerce")
+    zones["avg_temp"] = pd.to_numeric(zones["avg_temp"], errors="coerce")
+
+    variability_row = zones.sort_values("std_temp", ascending=False).iloc[0]
+    hottest_row = zones.sort_values("avg_temp", ascending=False).iloc[0]
+    coldest_row = zones.sort_values("avg_temp", ascending=True).iloc[0]
+
+    out_of_band = None
+    if not comfort_summary_df.empty and "out_of_band_pct" in comfort_summary_df.columns:
+        out_of_band = pd.to_numeric(
+            comfort_summary_df.iloc[0]["out_of_band_pct"],
+            errors="coerce",
+        )
+    if out_of_band is None or pd.isna(out_of_band):
+        out_of_band = pd.to_numeric(
+            zones.get("comfort_exceedance_pct", pd.Series(dtype=float)),
+            errors="coerce",
+        ).mean()
+
+    return {
+        "high_variability_zone": str(variability_row["space_id"]),
+        "high_variability_std_temp": _fmt_number(variability_row["std_temp"], decimals=2),
+        "hottest_zone": str(hottest_row["space_id"]),
+        "hottest_zone_avg_temp": _fmt_number(hottest_row["avg_temp"], decimals=2),
+        "coldest_zone": str(coldest_row["space_id"]),
+        "coldest_zone_avg_temp": _fmt_number(coldest_row["avg_temp"], decimals=2),
+        "overall_out_of_band_pct": _fmt_number(out_of_band, decimals=2),
+    }

--- a/src/viz/streamlit_dashboard.py
+++ b/src/viz/streamlit_dashboard.py
@@ -1,0 +1,457 @@
+"""
+Streamlit proof-of-concept dashboard for PostgreSQL-backed occupancy and HVAC insights.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+import sys
+from typing import Optional, Tuple
+
+# Make `src.*` imports work even when streamlit is launched outside repo root.
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from src.viz.dashboard_data import (
+    fetch_hvac_comfort_summary,
+    fetch_hvac_daily,
+    fetch_hvac_hourly,
+    fetch_hvac_kpis,
+    fetch_hvac_zone_stats,
+    fetch_occupancy_daily,
+    fetch_occupancy_heatmap,
+    fetch_occupancy_kpis,
+    fetch_occupancy_space_stats,
+)
+from src.viz.dashboard_insights import POSTGRES_DOW_LABELS, derive_hvac_insights, derive_occupancy_insights
+
+DOW_ORDER = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+
+
+def _fmt_int(value: object) -> str:
+    numeric = pd.to_numeric(value, errors="coerce")
+    if pd.isna(numeric):
+        return "N/A"
+    return f"{int(numeric):,}"
+
+
+def _fmt_float(value: object, decimals: int = 2) -> str:
+    numeric = pd.to_numeric(value, errors="coerce")
+    if pd.isna(numeric):
+        return "N/A"
+    return f"{float(numeric):,.{decimals}f}"
+
+
+def _extract_bounds(kpi_df: pd.DataFrame) -> Tuple[date, date]:
+    if kpi_df.empty or pd.isna(kpi_df.iloc[0]["min_ts"]) or pd.isna(kpi_df.iloc[0]["max_ts"]):
+        today = pd.Timestamp.utcnow().date()
+        return today, today
+    min_date = pd.Timestamp(kpi_df.iloc[0]["min_ts"]).date()
+    max_date = pd.Timestamp(kpi_df.iloc[0]["max_ts"]).date()
+    return min_date, max_date
+
+
+def _normalize_selected_range(
+    value: object,
+    default_start: date,
+    default_end: date,
+) -> Tuple[date, date]:
+    if isinstance(value, tuple) and len(value) == 2:
+        start, end = value
+        return (start or default_start, end or default_end)
+    if isinstance(value, list) and len(value) == 2:
+        start, end = value
+        return (start or default_start, end or default_end)
+    if isinstance(value, date):
+        return value, value
+    return default_start, default_end
+
+
+def _to_datetime_window(start_day: date, end_day: date) -> tuple[pd.Timestamp, pd.Timestamp]:
+    start = pd.Timestamp(start_day)
+    end = pd.Timestamp(end_day) + pd.Timedelta(days=1) - pd.Timedelta(seconds=1)
+    return start, end
+
+
+@st.cache_data(ttl=900, show_spinner=False)
+def _cached_occ_kpis(schema: str, env_path: str, start_ts: Optional[pd.Timestamp], end_ts: Optional[pd.Timestamp]) -> pd.DataFrame:
+    return fetch_occupancy_kpis(schema=schema, env_path=env_path, start_ts=start_ts, end_ts=end_ts)
+
+
+@st.cache_data(ttl=900, show_spinner=False)
+def _cached_occ_daily(schema: str, env_path: str, start_ts: pd.Timestamp, end_ts: pd.Timestamp) -> pd.DataFrame:
+    return fetch_occupancy_daily(schema=schema, env_path=env_path, start_ts=start_ts, end_ts=end_ts)
+
+
+@st.cache_data(ttl=900, show_spinner=False)
+def _cached_occ_heatmap(schema: str, env_path: str, start_ts: pd.Timestamp, end_ts: pd.Timestamp) -> pd.DataFrame:
+    return fetch_occupancy_heatmap(schema=schema, env_path=env_path, start_ts=start_ts, end_ts=end_ts)
+
+
+@st.cache_data(ttl=900, show_spinner=False)
+def _cached_occ_space_stats(schema: str, env_path: str, start_ts: pd.Timestamp, end_ts: pd.Timestamp) -> pd.DataFrame:
+    return fetch_occupancy_space_stats(schema=schema, env_path=env_path, start_ts=start_ts, end_ts=end_ts)
+
+
+@st.cache_data(ttl=900, show_spinner=False)
+def _cached_hvac_kpis(schema: str, env_path: str, start_ts: Optional[pd.Timestamp], end_ts: Optional[pd.Timestamp]) -> pd.DataFrame:
+    return fetch_hvac_kpis(schema=schema, env_path=env_path, start_ts=start_ts, end_ts=end_ts)
+
+
+@st.cache_data(ttl=900, show_spinner=False)
+def _cached_hvac_daily(schema: str, env_path: str, start_ts: pd.Timestamp, end_ts: pd.Timestamp) -> pd.DataFrame:
+    return fetch_hvac_daily(schema=schema, env_path=env_path, start_ts=start_ts, end_ts=end_ts)
+
+
+@st.cache_data(ttl=900, show_spinner=False)
+def _cached_hvac_hourly(schema: str, env_path: str, start_ts: pd.Timestamp, end_ts: pd.Timestamp) -> pd.DataFrame:
+    return fetch_hvac_hourly(schema=schema, env_path=env_path, start_ts=start_ts, end_ts=end_ts)
+
+
+@st.cache_data(ttl=900, show_spinner=False)
+def _cached_hvac_zone_stats(
+    schema: str,
+    env_path: str,
+    comfort_low: float,
+    comfort_high: float,
+    start_ts: pd.Timestamp,
+    end_ts: pd.Timestamp,
+) -> pd.DataFrame:
+    return fetch_hvac_zone_stats(
+        schema=schema,
+        env_path=env_path,
+        comfort_low=comfort_low,
+        comfort_high=comfort_high,
+        start_ts=start_ts,
+        end_ts=end_ts,
+    )
+
+
+@st.cache_data(ttl=900, show_spinner=False)
+def _cached_hvac_comfort_summary(
+    schema: str,
+    env_path: str,
+    comfort_low: float,
+    comfort_high: float,
+    start_ts: pd.Timestamp,
+    end_ts: pd.Timestamp,
+) -> pd.DataFrame:
+    return fetch_hvac_comfort_summary(
+        schema=schema,
+        env_path=env_path,
+        comfort_low=comfort_low,
+        comfort_high=comfort_high,
+        start_ts=start_ts,
+        end_ts=end_ts,
+    )
+
+
+def _load_kpis(schema: str, env_path: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+    occ = _cached_occ_kpis(schema=schema, env_path=env_path, start_ts=None, end_ts=None)
+    hvac = _cached_hvac_kpis(schema=schema, env_path=env_path, start_ts=None, end_ts=None)
+    return occ, hvac
+
+
+def _coerce_numeric(df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:
+    out = df.copy()
+    for col in columns:
+        if col in out.columns:
+            out[col] = pd.to_numeric(out[col], errors="coerce")
+    return out
+
+
+def main() -> None:
+    st.set_page_config(
+        page_title="HVAC & Occupancy POC Dashboard",
+        page_icon="🏢",
+        layout="wide",
+    )
+    st.title("HVAC & Occupancy POC Dashboard")
+    st.caption(
+        "PostgreSQL-backed historical dashboard with separate occupancy and HVAC insights. "
+        "No direct occupancy↔HVAC join is used in this version."
+    )
+
+    with st.sidebar:
+        st.header("Settings")
+        env_path = st.text_input("Env file path", value=".env")
+        schema = st.text_input("DB schema", value="public")
+        top_n = st.slider("Top-N for ranking charts", min_value=5, max_value=30, value=10, step=1)
+        st.divider()
+        st.subheader("HVAC Comfort Band (°F)")
+        comfort_low = st.number_input("Lower bound", value=70.0, step=0.5)
+        comfort_high = st.number_input("Upper bound", value=76.0, step=0.5)
+        if comfort_high <= comfort_low:
+            st.error("Upper comfort bound must be greater than lower bound.")
+            st.stop()
+
+    try:
+        occ_kpis_all, hvac_kpis_all = _load_kpis(schema=schema, env_path=env_path)
+    except Exception as exc:
+        st.error(f"Failed to load dashboard KPI data from PostgreSQL: {exc}")
+        st.stop()
+
+    occ_min, occ_max = _extract_bounds(occ_kpis_all)
+    hvac_min, hvac_max = _extract_bounds(hvac_kpis_all)
+
+    with st.sidebar:
+        st.divider()
+        st.subheader("Occupancy Date Range")
+        selected_occ = st.date_input(
+            "Occupancy window",
+            value=(occ_min, occ_max),
+            min_value=occ_min,
+            max_value=occ_max,
+            key="occ_window",
+        )
+        st.subheader("HVAC Date Range")
+        selected_hvac = st.date_input(
+            "HVAC window",
+            value=(hvac_min, hvac_max),
+            min_value=hvac_min,
+            max_value=hvac_max,
+            key="hvac_window",
+        )
+
+    occ_start_date, occ_end_date = _normalize_selected_range(selected_occ, occ_min, occ_max)
+    hvac_start_date, hvac_end_date = _normalize_selected_range(selected_hvac, hvac_min, hvac_max)
+    occ_start_ts, occ_end_ts = _to_datetime_window(occ_start_date, occ_end_date)
+    hvac_start_ts, hvac_end_ts = _to_datetime_window(hvac_start_date, hvac_end_date)
+
+    tabs = st.tabs(["Overview", "Occupancy Insights", "HVAC Insights"])
+
+    with tabs[0]:
+        st.subheader("Coverage & KPI Snapshot")
+        left, right = st.columns(2)
+
+        with left:
+            st.markdown("**Occupancy Dataset (`space_occupancy`)**")
+            row = occ_kpis_all.iloc[0] if not occ_kpis_all.empty else {}
+            c1, c2, c3 = st.columns(3)
+            c1.metric("Rows", _fmt_int(row.get("rows")))
+            c2.metric("Spaces", _fmt_int(row.get("spaces")))
+            c3.metric("Date Span", f"{occ_min} → {occ_max}")
+            c4, c5, c6 = st.columns(3)
+            c4.metric("Average Occupancy", _fmt_float(row.get("avg_occ")))
+            c5.metric("Median Occupancy", _fmt_float(row.get("median_occ")))
+            c6.metric("Peak Occupancy", _fmt_int(row.get("peak_occ")))
+
+        with right:
+            st.markdown("**HVAC Dataset (`hvac`)**")
+            row = hvac_kpis_all.iloc[0] if not hvac_kpis_all.empty else {}
+            c1, c2, c3 = st.columns(3)
+            c1.metric("Rows", _fmt_int(row.get("rows")))
+            c2.metric("VAV Zones", _fmt_int(row.get("zones")))
+            c3.metric("Date Span", f"{hvac_min} → {hvac_max}")
+            c4, c5, c6 = st.columns(3)
+            c4.metric("Average Zone Temp (°F)", _fmt_float(row.get("avg_temp")))
+            c5.metric("Median Zone Temp (°F)", _fmt_float(row.get("median_temp")))
+            c6.metric("P95 Zone Temp (°F)", _fmt_float(row.get("p95_temp")))
+
+        st.info(
+            "This POC intentionally keeps occupancy and HVAC analyses separate because current "
+            "database identifiers and time ranges do not support a trustworthy direct join."
+        )
+
+    with tabs[1]:
+        st.subheader("Occupancy Trends and Room Utilization")
+        try:
+            occ_kpis = _cached_occ_kpis(schema=schema, env_path=env_path, start_ts=occ_start_ts, end_ts=occ_end_ts)
+            occ_daily = _cached_occ_daily(schema=schema, env_path=env_path, start_ts=occ_start_ts, end_ts=occ_end_ts)
+            occ_heatmap = _cached_occ_heatmap(schema=schema, env_path=env_path, start_ts=occ_start_ts, end_ts=occ_end_ts)
+            occ_spaces = _cached_occ_space_stats(schema=schema, env_path=env_path, start_ts=occ_start_ts, end_ts=occ_end_ts)
+        except Exception as exc:
+            st.error(f"Failed to load occupancy insights: {exc}")
+            st.stop()
+
+        if occ_daily.empty:
+            st.warning("No occupancy data found for the selected date range.")
+        else:
+            row = occ_kpis.iloc[0] if not occ_kpis.empty else {}
+            m1, m2, m3 = st.columns(3)
+            m1.metric("Rows (Filtered)", _fmt_int(row.get("rows")))
+            m2.metric("Spaces (Filtered)", _fmt_int(row.get("spaces")))
+            m3.metric("Peak Occupancy (Filtered)", _fmt_int(row.get("peak_occ")))
+
+            occ_daily = _coerce_numeric(occ_daily, ["avg_occ", "peak_occ", "samples"])
+            fig_daily = px.line(
+                occ_daily,
+                x="day",
+                y=["avg_occ", "peak_occ"],
+                markers=True,
+                labels={"value": "Occupancy", "variable": "Metric", "day": "Date"},
+                title="Daily Occupancy Trend",
+            )
+            st.plotly_chart(fig_daily, use_container_width=True)
+
+            if not occ_heatmap.empty:
+                heat = _coerce_numeric(occ_heatmap, ["day_of_week", "hour_of_day", "avg_occ"])
+                heat["day_name"] = heat["day_of_week"].map(POSTGRES_DOW_LABELS)
+                heat["day_name"] = pd.Categorical(heat["day_name"], categories=DOW_ORDER, ordered=True)
+                pivot = (
+                    heat.pivot(index="day_name", columns="hour_of_day", values="avg_occ")
+                    .reindex(DOW_ORDER)
+                )
+                fig_heat = px.imshow(
+                    pivot,
+                    aspect="auto",
+                    labels={"x": "Hour of Day", "y": "Day of Week", "color": "Avg Occupancy"},
+                    title="Occupancy Heatmap (Average Count)",
+                    color_continuous_scale="YlGnBu",
+                )
+                st.plotly_chart(fig_heat, use_container_width=True)
+
+            if not occ_spaces.empty:
+                spaces = _coerce_numeric(occ_spaces, ["avg_occ", "peak_occ", "samples"])
+                top_spaces = spaces.sort_values("avg_occ", ascending=False).head(top_n).sort_values("avg_occ")
+                fig_top = px.bar(
+                    top_spaces,
+                    x="avg_occ",
+                    y="space_label",
+                    orientation="h",
+                    labels={"avg_occ": "Average Occupancy", "space_label": "Space"},
+                    title=f"Top {top_n} Spaces by Average Occupancy",
+                )
+                st.plotly_chart(fig_top, use_container_width=True)
+
+                insights = derive_occupancy_insights(occ_heatmap, occ_spaces)
+                i1, i2, i3 = st.columns(3)
+                i1.metric("Busiest Day", str(insights["busiest_day"]))
+                i2.metric(
+                    "Busiest Hour",
+                    str(insights["busiest_hour"]),
+                    delta=f"Avg {insights['busiest_hour_avg_occ']}",
+                )
+                i3.metric(
+                    "Highest-Utilization Space",
+                    str(insights["highest_util_space"]),
+                    delta=f"Avg {insights['highest_util_avg_occ']}",
+                )
+                low_spaces = insights["low_util_spaces"]
+                if low_spaces:
+                    st.caption("Low-utilization spaces (candidate review list): " + ", ".join(low_spaces))
+
+    with tabs[2]:
+        st.subheader("HVAC Zone Temperature Behavior")
+        try:
+            hvac_kpis = _cached_hvac_kpis(schema=schema, env_path=env_path, start_ts=hvac_start_ts, end_ts=hvac_end_ts)
+            hvac_daily = _cached_hvac_daily(schema=schema, env_path=env_path, start_ts=hvac_start_ts, end_ts=hvac_end_ts)
+            hvac_hourly = _cached_hvac_hourly(schema=schema, env_path=env_path, start_ts=hvac_start_ts, end_ts=hvac_end_ts)
+            hvac_zones = _cached_hvac_zone_stats(
+                schema=schema,
+                env_path=env_path,
+                comfort_low=float(comfort_low),
+                comfort_high=float(comfort_high),
+                start_ts=hvac_start_ts,
+                end_ts=hvac_end_ts,
+            )
+            hvac_comfort = _cached_hvac_comfort_summary(
+                schema=schema,
+                env_path=env_path,
+                comfort_low=float(comfort_low),
+                comfort_high=float(comfort_high),
+                start_ts=hvac_start_ts,
+                end_ts=hvac_end_ts,
+            )
+        except Exception as exc:
+            st.error(f"Failed to load HVAC insights: {exc}")
+            st.stop()
+
+        if hvac_daily.empty:
+            st.warning("No HVAC data found for the selected date range.")
+        else:
+            row = hvac_kpis.iloc[0] if not hvac_kpis.empty else {}
+            m1, m2, m3 = st.columns(3)
+            m1.metric("Rows (Filtered)", _fmt_int(row.get("rows")))
+            m2.metric("Zones (Filtered)", _fmt_int(row.get("zones")))
+            m3.metric("P95 Temp (Filtered)", _fmt_float(row.get("p95_temp")))
+
+            hvac_daily = _coerce_numeric(hvac_daily, ["avg_temp", "p95_temp", "samples"])
+            fig_daily = px.line(
+                hvac_daily,
+                x="day",
+                y=["avg_temp", "p95_temp"],
+                markers=True,
+                labels={"value": "Temperature (°F)", "variable": "Metric", "day": "Date"},
+                title="Daily HVAC Temperature Profile",
+            )
+            st.plotly_chart(fig_daily, use_container_width=True)
+
+            hvac_hourly = _coerce_numeric(hvac_hourly, ["hour_of_day", "avg_temp", "p90_temp"])
+            fig_hourly = px.line(
+                hvac_hourly,
+                x="hour_of_day",
+                y=["avg_temp", "p90_temp"],
+                markers=True,
+                labels={"hour_of_day": "Hour of Day", "value": "Temperature (°F)", "variable": "Metric"},
+                title="Hourly HVAC Temperature Profile",
+            )
+            st.plotly_chart(fig_hourly, use_container_width=True)
+
+            hvac_zones = _coerce_numeric(
+                hvac_zones,
+                ["avg_temp", "std_temp", "min_temp", "max_temp", "comfort_exceedance_pct", "samples"],
+            )
+            hottest = hvac_zones.sort_values("avg_temp", ascending=False).head(top_n).sort_values("avg_temp")
+            coldest = hvac_zones.sort_values("avg_temp", ascending=True).head(top_n).sort_values("avg_temp", ascending=False)
+
+            c_left, c_right = st.columns(2)
+            with c_left:
+                fig_hot = px.bar(
+                    hottest,
+                    x="avg_temp",
+                    y="space_id",
+                    orientation="h",
+                    title=f"Hottest {top_n} Zones (Average Temp)",
+                    labels={"avg_temp": "Average Temp (°F)", "space_id": "Zone"},
+                )
+                st.plotly_chart(fig_hot, use_container_width=True)
+            with c_right:
+                fig_cold = px.bar(
+                    coldest,
+                    x="avg_temp",
+                    y="space_id",
+                    orientation="h",
+                    title=f"Coldest {top_n} Zones (Average Temp)",
+                    labels={"avg_temp": "Average Temp (°F)", "space_id": "Zone"},
+                )
+                st.plotly_chart(fig_cold, use_container_width=True)
+
+            variability = hvac_zones.sort_values("std_temp", ascending=False).head(top_n).sort_values("std_temp")
+            fig_var = px.bar(
+                variability,
+                x="std_temp",
+                y="space_id",
+                orientation="h",
+                title=f"Highest Variability Zones (Top {top_n} by Temp Std Dev)",
+                labels={"std_temp": "Std Dev (°F)", "space_id": "Zone"},
+            )
+            st.plotly_chart(fig_var, use_container_width=True)
+
+            insights = derive_hvac_insights(hvac_zones, hvac_comfort)
+            i1, i2, i3 = st.columns(3)
+            i1.metric(
+                "Highest Variability Zone",
+                str(insights["high_variability_zone"]),
+                delta=f"Std {insights['high_variability_std_temp']} °F",
+            )
+            i2.metric(
+                "Hottest vs Coldest Zone",
+                f"{insights['hottest_zone']} / {insights['coldest_zone']}",
+                delta=f"{insights['hottest_zone_avg_temp']} °F / {insights['coldest_zone_avg_temp']} °F",
+            )
+            i3.metric(
+                "Out-of-Band Share",
+                f"{insights['overall_out_of_band_pct']}%",
+                delta=f"Band {comfort_low:.1f}°F to {comfort_high:.1f}°F",
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_dashboard_data.py
+++ b/tests/test_dashboard_data.py
@@ -1,0 +1,113 @@
+from datetime import datetime
+
+import pytest
+
+from src.viz import dashboard_data
+
+
+class FakeCursor:
+    def __init__(self, columns, rows):
+        self.description = [(col, None, None, None, None, None, None) for col in columns]
+        self._rows = rows
+        self.last_query = ""
+        self.last_params = None
+
+    def execute(self, query, params=None):
+        self.last_query = query
+        self.last_params = params
+
+    def fetchall(self):
+        return self._rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def _patch_connection(monkeypatch, fake_cursor):
+    monkeypatch.setattr(
+        dashboard_data,
+        "get_postgres_connection",
+        lambda env_path=".env": FakeConnection(fake_cursor),
+    )
+
+
+def test_fetch_occupancy_daily_uses_parameterized_time_filters(monkeypatch):
+    cursor = FakeCursor(
+        columns=["day", "avg_occ", "peak_occ", "samples"],
+        rows=[],
+    )
+    _patch_connection(monkeypatch, cursor)
+
+    dashboard_data.fetch_occupancy_daily(
+        schema="public",
+        env_path=".env",
+        start_ts="2024-01-01 00:00:00",
+        end_ts="2024-01-31 23:59:59",
+    )
+
+    assert "beginning >= %s" in cursor.last_query
+    assert "beginning <= %s" in cursor.last_query
+    assert isinstance(cursor.last_params[0], datetime)
+    assert isinstance(cursor.last_params[1], datetime)
+    assert cursor.last_params[0] <= cursor.last_params[1]
+
+
+def test_fetch_hvac_zone_stats_param_order(monkeypatch):
+    cursor = FakeCursor(
+        columns=[
+            "space_id",
+            "avg_temp",
+            "std_temp",
+            "min_temp",
+            "max_temp",
+            "comfort_exceedance_pct",
+            "samples",
+        ],
+        rows=[("Zone-A", 72.0, 2.0, 68.0, 78.0, 10.0, 100)],
+    )
+    _patch_connection(monkeypatch, cursor)
+
+    df = dashboard_data.fetch_hvac_zone_stats(
+        schema="public",
+        env_path=".env",
+        comfort_low=69.0,
+        comfort_high=75.0,
+        start_ts="2024-07-01 00:00:00",
+        end_ts="2024-07-15 23:59:59",
+    )
+
+    assert cursor.last_params[0] == 69.0
+    assert cursor.last_params[1] == 75.0
+    assert isinstance(cursor.last_params[2], datetime)
+    assert isinstance(cursor.last_params[3], datetime)
+    assert list(df.columns) == [
+        "space_id",
+        "avg_temp",
+        "std_temp",
+        "min_temp",
+        "max_temp",
+        "comfort_exceedance_pct",
+        "samples",
+    ]
+
+
+def test_invalid_schema_is_rejected():
+    with pytest.raises(ValueError):
+        dashboard_data.fetch_hvac_kpis(schema="public;drop table hvac", env_path=".env")

--- a/tests/test_dashboard_insights.py
+++ b/tests/test_dashboard_insights.py
@@ -1,0 +1,69 @@
+import pandas as pd
+
+from src.viz.dashboard_insights import derive_hvac_insights, derive_occupancy_insights
+
+
+def test_derive_occupancy_insights_expected_values():
+    heatmap = pd.DataFrame(
+        {
+            "day_of_week": [1, 1, 2, 2],
+            "hour_of_day": [9, 10, 9, 10],
+            "avg_occ": [15.0, 20.0, 10.0, 11.0],
+            "samples": [100, 100, 100, 100],
+        }
+    )
+    spaces = pd.DataFrame(
+        {
+            "space_id": ["1", "2", "3", "4"],
+            "space_label": ["DBH 1001", "DBH 1002", "DBH 1003", "DBH 1004"],
+            "avg_occ": [12.0, 8.5, 3.2, 2.4],
+            "peak_occ": [40, 32, 10, 8],
+            "samples": [100, 100, 100, 100],
+        }
+    )
+
+    insights = derive_occupancy_insights(heatmap, spaces, low_space_count=2)
+
+    assert insights["busiest_day"] == "Monday"
+    assert insights["busiest_hour"] == "10:00"
+    assert insights["busiest_hour_avg_occ"] == "20.00"
+    assert insights["highest_util_space"] == "DBH 1001"
+    assert insights["highest_util_avg_occ"] == "12.00"
+    assert insights["low_util_spaces"] == ["DBH 1004", "DBH 1003"]
+
+
+def test_derive_hvac_insights_uses_comfort_summary_and_variability():
+    zones = pd.DataFrame(
+        {
+            "space_id": ["Zone-A", "Zone-B", "Zone-C"],
+            "avg_temp": [74.0, 70.5, 78.2],
+            "std_temp": [1.2, 3.1, 2.0],
+            "comfort_exceedance_pct": [8.0, 12.0, 25.0],
+            "samples": [1000, 1000, 1000],
+        }
+    )
+    comfort_summary = pd.DataFrame(
+        {
+            "below_band_pct": [5.0],
+            "above_band_pct": [9.0],
+            "out_of_band_pct": [14.0],
+        }
+    )
+
+    insights = derive_hvac_insights(zones, comfort_summary)
+
+    assert insights["high_variability_zone"] == "Zone-B"
+    assert insights["high_variability_std_temp"] == "3.10"
+    assert insights["hottest_zone"] == "Zone-C"
+    assert insights["coldest_zone"] == "Zone-B"
+    assert insights["overall_out_of_band_pct"] == "14.00"
+
+
+def test_derive_insights_empty_frames_are_safe():
+    occ = derive_occupancy_insights(pd.DataFrame(), pd.DataFrame())
+    hvac = derive_hvac_insights(pd.DataFrame(), pd.DataFrame())
+
+    assert occ["busiest_day"] == "N/A"
+    assert occ["low_util_spaces"] == []
+    assert hvac["high_variability_zone"] == "N/A"
+    assert hvac["overall_out_of_band_pct"] == "N/A"

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -1,0 +1,52 @@
+import pandas as pd
+
+from src.data.preprocess import prepare_occupancy_forecast_dataset
+from src.models import ProphetOccupancyModel, predict_occupancy
+
+
+def test_end_to_end_training_eval_and_inference():
+    ts = pd.date_range("2025-01-01 00:00:00", periods=14 * 24 * 4, freq="15min")
+    occ_values = [0 if t.hour < 8 or t.hour >= 18 else 5 for t in ts]
+    occ_df = pd.DataFrame(
+        {
+            "timestamp": ts,
+            "zone_id": ["A"] * len(ts),
+            "occupancy_count": occ_values,
+        }
+    )
+    weather_df = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2025-01-01 00:00:00", periods=14 * 24, freq="1h"),
+            "outside_temp": [58 + (i % 24) * 0.2 for i in range(14 * 24)],
+        }
+    )
+
+    features = prepare_occupancy_forecast_dataset(
+        occ_df=occ_df,
+        weather_df=weather_df,
+        zone_id="A",
+        freq="15min",
+        dropna_for_training=True,
+    )
+    model_df = features.rename(columns={"timestamp": "ds", "occupancy_count": "y"})[
+        ["ds", "y", "outside_temp"]
+    ]
+    split_idx = int(len(model_df) * 0.8)
+
+    model = ProphetOccupancyModel(zone_id="A", freq="15min")
+    model.fit(model_df.iloc[:split_idx])
+    metrics = model.evaluate(model_df.iloc[split_idx:])
+
+    assert {"binary_accuracy", "precision", "recall", "f1", "mae"}.issubset(metrics.keys())
+
+    forecast = predict_occupancy(
+        zone_id="A",
+        start_ts="2025-01-14 00:00:00",
+        end_ts="2025-01-14 23:45:00",
+        freq="15min",
+        model=model,
+    )
+
+    assert len(forecast) == 96
+    assert forecast["timestamp"].is_monotonic_increasing
+    assert {"zone_id", "pred_occupancy_count", "pred_is_occupied"}.issubset(forecast.columns)

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,32 @@
+import pandas as pd
+
+from src.data.preprocess import prepare_occupancy_forecast_dataset
+
+
+def test_feature_alignment_no_future_leakage():
+    ts = pd.date_range("2025-01-01 00:00:00", periods=12, freq="15min")
+    occ = pd.DataFrame(
+        {
+            "timestamp": ts,
+            "zone_id": ["A"] * len(ts),
+            "occupancy_count": list(range(len(ts))),
+        }
+    )
+    weather = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2025-01-01 00:00:00", periods=4, freq="1h"),
+            "outside_temp": [60, 61, 62, 63],
+        }
+    )
+
+    features = prepare_occupancy_forecast_dataset(
+        occ_df=occ,
+        weather_df=weather,
+        zone_id="A",
+        lag_periods=[1, 4],
+        dropna_for_training=False,
+    )
+
+    # lag(1) at index i must equal occupancy_count at i-1.
+    assert features.loc[2, "occupancy_lag_1"] == features.loc[1, "occupancy_count"]
+    assert features.loc[5, "occupancy_lag_4"] == features.loc[1, "occupancy_count"]

--- a/tests/test_prophet_model.py
+++ b/tests/test_prophet_model.py
@@ -1,0 +1,53 @@
+import pandas as pd
+
+from src.models.prophet_baseline import ProphetOccupancyModel
+
+
+def test_date_range_inference_returns_full_coverage():
+    train = pd.DataFrame(
+        {
+            "ds": pd.date_range("2025-01-01 00:00:00", periods=200, freq="15min"),
+            "y": [0, 1, 2, 3] * 50,
+        }
+    )
+    model = ProphetOccupancyModel(zone_id="A", freq="15min")
+    model.fit(train)
+
+    start = pd.Timestamp("2025-01-03 00:00:00")
+    end = pd.Timestamp("2025-01-03 03:45:00")
+    forecast = model.predict_date_range(start_ts=start, end_ts=end)
+
+    assert forecast["ds"].min() == start
+    assert forecast["ds"].max() == end
+    assert len(forecast) == 16
+    assert {"pred_occupancy_count", "pred_is_occupied"}.issubset(set(forecast.columns))
+
+
+def test_binary_conversion_definition_threshold():
+    model = ProphetOccupancyModel(zone_id="A", freq="15min")
+    model.backend = "seasonal_naive"
+    model._seasonal = None  # Not used by this patched path.
+    model._fitted_df = pd.DataFrame({"ds": [pd.Timestamp("2025-01-01")], "y": [0]})
+
+    def fake_predict_core(_future_df):
+        return pd.DataFrame(
+            {
+                "ds": pd.to_datetime(["2025-01-01 00:00:00", "2025-01-01 00:15:00"]),
+                "yhat": [0.8, 1.2],
+                "yhat_lower": [0.8, 1.2],
+                "yhat_upper": [0.8, 1.2],
+                "pred_occupancy_count": [0.8, 1.2],
+                "pred_is_occupied": [False, True],
+            }
+        )
+
+    model.predict_dataframe = fake_predict_core  # type: ignore[method-assign]
+
+    test_df = pd.DataFrame(
+        {
+            "ds": pd.to_datetime(["2025-01-01 00:00:00", "2025-01-01 00:15:00"]),
+            "y": [0.0, 2.0],  # true binary => [False, True]
+        }
+    )
+    metrics = model.evaluate(test_df)
+    assert metrics["binary_accuracy"] == 1.0


### PR DESCRIPTION
## Summary
- Add a Streamlit dashboard with Overview, Occupancy, and HVAC tabs that surface separate KPI cards, visuals, and insight text for each dataset.
- Introduce parameterized, cached SQL query helpers plus insight calculations and error handling so the UI reads directly from PostgreSQL via the existing connection helper.
- Document the new local run workflow (requirements, env vars, CLI command) and refresh data/model helpers/tests to support the dashboard’s needs.

## Testing
- Not run (not requested)